### PR TITLE
Allow providing a toggle function

### DIFF
--- a/src/useToggle/index.js
+++ b/src/useToggle/index.js
@@ -4,28 +4,36 @@
  * @see    https://developer.wordpress.org/block-editor/reference-guides/packages/packages-element/
  * @ignore
  */
-import { useState, useCallback } from '@wordpress/element';
+import { useReducer } from '@wordpress/element';
 
 /**
- * This hook takes a parameter with value true or false and toggles that value to opposite.
+ * Reducer dispatch that takes a parameter with value true or false and toggles that value to opposite.
+ *
+ * @ignore
+ */
+const defaultToggleFunction = ( value ) => ! Boolean( value );
+
+/**
+ * This hook takes a parameter with value and allows for quickly toggling the value.
  *
  * @function
- * @since      1.0.0
- * @param  	   {boolean}    initialState    Post content.
- * @return     {Array}                      Returns a stateful value, and a function to update it.
+ * @since      1.1.0
+ * @param  	   {any|boolean}    initialValue      Initial value of the toggle.
+ * @param  	   {Function}       toggleFunction    A toggle function. This allows for non boolean toggles.
+ * @return     {Array}                        	  Returns a stateful value, and a function to update it.
  * @example
  *
- * const [ isEditing, toggleIsEditing ] = useToggle();
+ * const [ value1, toggleValue1 ] = useToggle();
+ * const [ value2, toggleValue2 ] = useToggle( true );
+ * const [ value3, toggleValue3 ] = useToggle( 'start', customToggleFunction );
  */
-function useToggle( initialState = false ) {
-	// Initialize the state
-	const [ state, setState ] = useState( Boolean( initialState ) );
-
-	// Define and memorize toggler function in case we pass down the component,
-	// This function change the boolean value to it's opposite value
-	const toggle = useCallback( () => setState( ( currentState ) => ! currentState ), [] );
-
-	return [ Boolean( state ), toggle ];
+function useToggle( initialValue, toggleFunction ) {
+	return useReducer( toggleFunction || defaultToggleFunction, initialValue );
 }
+
+useToggle.defaultProps = {
+	initialValue: false,
+	toggleFunction: defaultToggleFunction,
+};
 
 export default useToggle;


### PR DESCRIPTION
This PR further extends the existing functionality of the `useToggle` hook by allowing it to accept a custom toggle function or even non-boolean initial value.