### PR TITLE
Maintenance

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,0 +1,4 @@
+#!/bin/sh
+. "$(dirname "$0")/_/husky.sh"
+
+npx lint-staged

--- a/.npmignore
+++ b/.npmignore
@@ -1,15 +1,74 @@
-**/node_modules/**
-coverage
-cypress
-node_modules
-*.sublime-project
-*.sublime-workspace
-*.php
+# Logs
+logs
+*.log
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+
+# Sass
+.sass-cache/
+
+# OS X metadata
 .DS_Store
-.ftppass
-*.cache
+
+# Windows junk
+Thumbs.db
+
+# Coverage directory used by tools like istanbul
+coverage
+
+# Compiled binary addons (https://nodejs.org/api/addons.html)
+build/Release
+
+# Dependency directories
+node_modules/
+vendor/
+build/
+dist/
+
+# Unit tests
+/tmp
+/tests/bin/tmp
+/tests/e2e-tests/config/local-*.json
+
+# Optional npm cache directory
+.npm
+
+# Visual studio code
 .vscode/*
-docs/*
-sftp.json.github/
-readme.txt
+!.vscode/settings.json
+!.vscode/tasks.json
+!.vscode/launch.json
+!.vscode/extensions.json
+*.code-workspace
+
+# Optional eslint cache
+.eslintcache
+
+# Output of 'npm pack'
+*.tgz
+
+# dotenv environment variables file
+.env
+
+# IDE configuration files
 .idea
+
+# Husky configuration files
+.husky
+
+# Documentation
+docs/
+
+# .ignore files and development configs
+.editorconfig
+.eslintignore
+.gitattributes
+.prettierignore
+.prettierrc.js
+babel.config.js
+renovate.json
+package-lock.json
+
+# Source files
+src/

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "@sixach/wp-react-hooks",
-	"version": "1.1.0",
+	"version": "1.1.1",
 	"lockfileVersion": 2,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "@sixach/wp-react-hooks",
-			"version": "1.1.0",
+			"version": "1.1.1",
 			"license": "GPL-3.0-or-later",
 			"dependencies": {
 				"@wordpress/element": "^4.0.0"

--- a/package-lock.json
+++ b/package-lock.json
@@ -430,14 +430,14 @@
 			}
 		},
 		"node_modules/@babel/helpers": {
-			"version": "7.14.8",
-			"resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.14.8.tgz",
-			"integrity": "sha512-ZRDmI56pnV+p1dH6d+UN6GINGz7Krps3+270qqI9UJ4wxYThfAIcI5i7j5vXC4FJ3Wap+S9qcebxeYiqn87DZw==",
+			"version": "7.15.3",
+			"resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.15.3.tgz",
+			"integrity": "sha512-HwJiz52XaS96lX+28Tnbu31VeFSQJGOeKHJeaEPQlTl7PnlhFElWPj8tUXtqFIzeN86XxXoBr+WFAyK2PPVz6g==",
 			"dev": true,
 			"dependencies": {
 				"@babel/template": "^7.14.5",
-				"@babel/traverse": "^7.14.8",
-				"@babel/types": "^7.14.8"
+				"@babel/traverse": "^7.15.0",
+				"@babel/types": "^7.15.0"
 			},
 			"engines": {
 				"node": ">=6.9.0"
@@ -458,9 +458,9 @@
 			}
 		},
 		"node_modules/@babel/parser": {
-			"version": "7.15.2",
-			"resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.15.2.tgz",
-			"integrity": "sha512-bMJXql1Ss8lFnvr11TZDH4ArtwlAS5NG9qBmdiFW2UHHm6MVoR+GDc5XE2b9K938cyjc9O6/+vjjcffLDtfuDg==",
+			"version": "7.15.3",
+			"resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.15.3.tgz",
+			"integrity": "sha512-O0L6v/HvqbdJawj0iBEfVQMc3/6WP+AeOsovsIgBFyJaG+W2w7eqvZB7puddATmWuARlm1SX7DwxJ/JJUnDpEA==",
 			"dev": true,
 			"bin": {
 				"parser": "bin/babel-parser.js"
@@ -1013,9 +1013,9 @@
 			}
 		},
 		"node_modules/@babel/plugin-transform-block-scoping": {
-			"version": "7.14.5",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-block-scoping/-/plugin-transform-block-scoping-7.14.5.tgz",
-			"integrity": "sha512-LBYm4ZocNgoCqyxMLoOnwpsmQ18HWTQvql64t3GvMUzLQrNoV1BDG0lNftC8QKYERkZgCCT/7J5xWGObGAyHDw==",
+			"version": "7.15.3",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-block-scoping/-/plugin-transform-block-scoping-7.15.3.tgz",
+			"integrity": "sha512-nBAzfZwZb4DkaGtOes1Up1nOAp9TDRRFw4XBzBBSG9QK7KVFmYzgj9o9sbPv7TX5ofL4Auq4wZnxCoPnI/lz2Q==",
 			"dev": true,
 			"dependencies": {
 				"@babel/helper-plugin-utils": "^7.14.5"
@@ -1727,9 +1727,9 @@
 			}
 		},
 		"node_modules/@babel/runtime": {
-			"version": "7.14.8",
-			"resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.14.8.tgz",
-			"integrity": "sha512-twj3L8Og5SaCRCErB4x4ajbvBIVV77CGeFglHpeg5WC5FF8TZzBWXtTJ4MqaD9QszLYTtr+IsaAL2rEUevb+eg==",
+			"version": "7.15.3",
+			"resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.15.3.tgz",
+			"integrity": "sha512-OvwMLqNXkCXSz1kSm58sEsNuhqOx/fKpnUnKnFB5v8uDda5bLNEHNgKPvhDN6IU0LDcnHQ90LlJ0Q6jnyBSIBA==",
 			"dependencies": {
 				"regenerator-runtime": "^0.13.4"
 			},
@@ -1738,9 +1738,9 @@
 			}
 		},
 		"node_modules/@babel/runtime-corejs3": {
-			"version": "7.14.9",
-			"resolved": "https://registry.npmjs.org/@babel/runtime-corejs3/-/runtime-corejs3-7.14.9.tgz",
-			"integrity": "sha512-64RiH2ON4/y8qYtoa8rUiyam/tUVyGqRyNYhe+vCRGmjnV4bUlZvY+mwd0RrmLoCpJpdq3RsrNqKb7SJdw/4kw==",
+			"version": "7.15.3",
+			"resolved": "https://registry.npmjs.org/@babel/runtime-corejs3/-/runtime-corejs3-7.15.3.tgz",
+			"integrity": "sha512-30A3lP+sRL6ml8uhoJSs+8jwpKzbw8CqBvDc1laeptxPm5FahumJxirigcbD2qTs71Sonvj1cyZB0OKGAmxQ+A==",
 			"dev": true,
 			"dependencies": {
 				"core-js-pure": "^3.16.0",
@@ -1854,9 +1854,9 @@
 			}
 		},
 		"node_modules/@eslint/eslintrc/node_modules/globals": {
-			"version": "13.10.0",
-			"resolved": "https://registry.npmjs.org/globals/-/globals-13.10.0.tgz",
-			"integrity": "sha512-piHC3blgLGFjvOuMmWZX60f+na1lXFDhQXBf1UYp2fXPXqvEUbOhNwi6BsQ0bQishwedgnjkwv1d9zKf+MWw3g==",
+			"version": "13.11.0",
+			"resolved": "https://registry.npmjs.org/globals/-/globals-13.11.0.tgz",
+			"integrity": "sha512-08/xrJ7wQjK9kkkRoI3OFUBbLx4f+6x3SGwcPvQ0QH6goFDrOU2oyAWrmh3dJezu65buo+HBMzAMQy6rovVC3g==",
 			"dev": true,
 			"dependencies": {
 				"type-fest": "^0.20.2"
@@ -2866,9 +2866,9 @@
 			}
 		},
 		"node_modules/@polka/url": {
-			"version": "1.0.0-next.15",
-			"resolved": "https://registry.npmjs.org/@polka/url/-/url-1.0.0-next.15.tgz",
-			"integrity": "sha512-15spi3V28QdevleWBNXE4pIls3nFZmBbUGrW9IVPwiQczuSb9n76TCB4bsk8TSel+I1OkHEdPhu5QKMfY6rQHA==",
+			"version": "1.0.0-next.17",
+			"resolved": "https://registry.npmjs.org/@polka/url/-/url-1.0.0-next.17.tgz",
+			"integrity": "sha512-0p1rCgM3LLbAdwBnc7gqgnvjHg9KpbhcSphergHShlkWz8EdPawoMJ3/VbezI0mGC5eKCDzMaPgF9Yca6cKvrg==",
 			"dev": true
 		},
 		"node_modules/@sinonjs/commons": {
@@ -3253,9 +3253,9 @@
 			"dev": true
 		},
 		"node_modules/@types/mdast": {
-			"version": "3.0.7",
-			"resolved": "https://registry.npmjs.org/@types/mdast/-/mdast-3.0.7.tgz",
-			"integrity": "sha512-YwR7OK8aPmaBvMMUi+pZXBNoW2unbVbfok4YRqGMJBe1dpDlzpRkJrYEYmvjxgs5JhuQmKfDexrN98u941Zasg==",
+			"version": "3.0.9",
+			"resolved": "https://registry.npmjs.org/@types/mdast/-/mdast-3.0.9.tgz",
+			"integrity": "sha512-IUlIhG2KNPjOEuXIblTjovD1XW8HPGeulA12nEyc6xhO4Yrrcs+xczAl4ucR3cpwVlE+vb2x9Z7pRmVP4bUHng==",
 			"dev": true,
 			"dependencies": {
 				"@types/unist": "*"
@@ -3274,9 +3274,9 @@
 			"dev": true
 		},
 		"node_modules/@types/node": {
-			"version": "16.4.13",
-			"resolved": "https://registry.npmjs.org/@types/node/-/node-16.4.13.tgz",
-			"integrity": "sha512-bLL69sKtd25w7p1nvg9pigE4gtKVpGTPojBFLMkGHXuUgap2sLqQt2qUnqmVCDfzGUL0DRNZP+1prIZJbMeAXg==",
+			"version": "16.7.1",
+			"resolved": "https://registry.npmjs.org/@types/node/-/node-16.7.1.tgz",
+			"integrity": "sha512-ncRdc45SoYJ2H4eWU9ReDfp3vtFqDYhjOsKlFFUDEn8V1Bgr2RjYal8YT5byfadWIRluhPFU6JiDOl0H6Sl87A==",
 			"dev": true
 		},
 		"node_modules/@types/normalize-package-data": {
@@ -3309,9 +3309,9 @@
 			"dev": true
 		},
 		"node_modules/@types/react": {
-			"version": "16.14.12",
-			"resolved": "https://registry.npmjs.org/@types/react/-/react-16.14.12.tgz",
-			"integrity": "sha512-7nOJgNsRbARhZhvwPm7cnzahtzEi5VJ9OvcQk8ExEEb1t+zaFklwLVkJz7G1kfxX4X/mDa/icTmzE0vTmqsqBg==",
+			"version": "16.14.14",
+			"resolved": "https://registry.npmjs.org/@types/react/-/react-16.14.14.tgz",
+			"integrity": "sha512-uwIWDYW8LznHzEMJl7ag9St1RsK0gw/xaFZ5+uI1ZM1HndwUgmPH3/wQkSb87GkOVg7shUxnpNW8DcN0AzvG5Q==",
 			"dependencies": {
 				"@types/prop-types": "*",
 				"@types/scheduler": "*",
@@ -3455,13 +3455,13 @@
 			}
 		},
 		"node_modules/@typescript-eslint/eslint-plugin": {
-			"version": "4.29.1",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-4.29.1.tgz",
-			"integrity": "sha512-AHqIU+SqZZgBEiWOrtN94ldR3ZUABV5dUG94j8Nms9rQnHFc8fvDOue/58K4CFz6r8OtDDc35Pw9NQPWo0Ayrw==",
+			"version": "4.29.2",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-4.29.2.tgz",
+			"integrity": "sha512-x4EMgn4BTfVd9+Z+r+6rmWxoAzBaapt4QFqE+d8L8sUtYZYLDTK6VG/y/SMMWA5t1/BVU5Kf+20rX4PtWzUYZg==",
 			"dev": true,
 			"dependencies": {
-				"@typescript-eslint/experimental-utils": "4.29.1",
-				"@typescript-eslint/scope-manager": "4.29.1",
+				"@typescript-eslint/experimental-utils": "4.29.2",
+				"@typescript-eslint/scope-manager": "4.29.2",
 				"debug": "^4.3.1",
 				"functional-red-black-tree": "^1.0.1",
 				"regexpp": "^3.1.0",
@@ -3519,15 +3519,15 @@
 			"dev": true
 		},
 		"node_modules/@typescript-eslint/experimental-utils": {
-			"version": "4.29.1",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/experimental-utils/-/experimental-utils-4.29.1.tgz",
-			"integrity": "sha512-kl6QG6qpzZthfd2bzPNSJB2YcZpNOrP6r9jueXupcZHnL74WiuSjaft7WSu17J9+ae9zTlk0KJMXPUj0daBxMw==",
+			"version": "4.29.2",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/experimental-utils/-/experimental-utils-4.29.2.tgz",
+			"integrity": "sha512-P6mn4pqObhftBBPAv4GQtEK7Yos1fz/MlpT7+YjH9fTxZcALbiiPKuSIfYP/j13CeOjfq8/fr9Thr2glM9ub7A==",
 			"dev": true,
 			"dependencies": {
 				"@types/json-schema": "^7.0.7",
-				"@typescript-eslint/scope-manager": "4.29.1",
-				"@typescript-eslint/types": "4.29.1",
-				"@typescript-eslint/typescript-estree": "4.29.1",
+				"@typescript-eslint/scope-manager": "4.29.2",
+				"@typescript-eslint/types": "4.29.2",
+				"@typescript-eslint/typescript-estree": "4.29.2",
 				"eslint-scope": "^5.1.1",
 				"eslint-utils": "^3.0.0"
 			},
@@ -3543,14 +3543,14 @@
 			}
 		},
 		"node_modules/@typescript-eslint/parser": {
-			"version": "4.29.1",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-4.29.1.tgz",
-			"integrity": "sha512-3fL5iN20hzX3Q4OkG7QEPFjZV2qsVGiDhEwwh+EkmE/w7oteiOvUNzmpu5eSwGJX/anCryONltJ3WDmAzAoCMg==",
+			"version": "4.29.2",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-4.29.2.tgz",
+			"integrity": "sha512-WQ6BPf+lNuwteUuyk1jD/aHKqMQ9jrdCn7Gxt9vvBnzbpj7aWEf+aZsJ1zvTjx5zFxGCt000lsbD9tQPEL8u6g==",
 			"dev": true,
 			"dependencies": {
-				"@typescript-eslint/scope-manager": "4.29.1",
-				"@typescript-eslint/types": "4.29.1",
-				"@typescript-eslint/typescript-estree": "4.29.1",
+				"@typescript-eslint/scope-manager": "4.29.2",
+				"@typescript-eslint/types": "4.29.2",
+				"@typescript-eslint/typescript-estree": "4.29.2",
 				"debug": "^4.3.1"
 			},
 			"engines": {
@@ -3570,13 +3570,13 @@
 			}
 		},
 		"node_modules/@typescript-eslint/scope-manager": {
-			"version": "4.29.1",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-4.29.1.tgz",
-			"integrity": "sha512-Hzv/uZOa9zrD/W5mftZa54Jd5Fed3tL6b4HeaOpwVSabJK8CJ+2MkDasnX/XK4rqP5ZTWngK1ZDeCi6EnxPQ7A==",
+			"version": "4.29.2",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-4.29.2.tgz",
+			"integrity": "sha512-mfHmvlQxmfkU8D55CkZO2sQOueTxLqGvzV+mG6S/6fIunDiD2ouwsAoiYCZYDDK73QCibYjIZmGhpvKwAB5BOA==",
 			"dev": true,
 			"dependencies": {
-				"@typescript-eslint/types": "4.29.1",
-				"@typescript-eslint/visitor-keys": "4.29.1"
+				"@typescript-eslint/types": "4.29.2",
+				"@typescript-eslint/visitor-keys": "4.29.2"
 			},
 			"engines": {
 				"node": "^8.10.0 || ^10.13.0 || >=11.10.1"
@@ -3587,9 +3587,9 @@
 			}
 		},
 		"node_modules/@typescript-eslint/types": {
-			"version": "4.29.1",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-4.29.1.tgz",
-			"integrity": "sha512-Jj2yu78IRfw4nlaLtKjVaGaxh/6FhofmQ/j8v3NXmAiKafbIqtAPnKYrf0sbGjKdj0hS316J8WhnGnErbJ4RCA==",
+			"version": "4.29.2",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-4.29.2.tgz",
+			"integrity": "sha512-K6ApnEXId+WTGxqnda8z4LhNMa/pZmbTFkDxEBLQAbhLZL50DjeY0VIDCml/0Y3FlcbqXZrABqrcKxq+n0LwzQ==",
 			"dev": true,
 			"engines": {
 				"node": "^8.10.0 || ^10.13.0 || >=11.10.1"
@@ -3600,13 +3600,13 @@
 			}
 		},
 		"node_modules/@typescript-eslint/typescript-estree": {
-			"version": "4.29.1",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-4.29.1.tgz",
-			"integrity": "sha512-lIkkrR9E4lwZkzPiRDNq0xdC3f2iVCUjw/7WPJ4S2Sl6C3nRWkeE1YXCQ0+KsiaQRbpY16jNaokdWnm9aUIsfw==",
+			"version": "4.29.2",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-4.29.2.tgz",
+			"integrity": "sha512-TJ0/hEnYxapYn9SGn3dCnETO0r+MjaxtlWZ2xU+EvytF0g4CqTpZL48SqSNn2hXsPolnewF30pdzR9a5Lj3DNg==",
 			"dev": true,
 			"dependencies": {
-				"@typescript-eslint/types": "4.29.1",
-				"@typescript-eslint/visitor-keys": "4.29.1",
+				"@typescript-eslint/types": "4.29.2",
+				"@typescript-eslint/visitor-keys": "4.29.2",
 				"debug": "^4.3.1",
 				"globby": "^11.0.3",
 				"is-glob": "^4.0.1",
@@ -3660,12 +3660,12 @@
 			"dev": true
 		},
 		"node_modules/@typescript-eslint/visitor-keys": {
-			"version": "4.29.1",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-4.29.1.tgz",
-			"integrity": "sha512-zLqtjMoXvgdZY/PG6gqA73V8BjqPs4af1v2kiiETBObp+uC6gRYnJLmJHxC0QyUrrHDLJPIWNYxoBV3wbcRlag==",
+			"version": "4.29.2",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-4.29.2.tgz",
+			"integrity": "sha512-bDgJLQ86oWHJoZ1ai4TZdgXzJxsea3Ee9u9wsTAvjChdj2WLcVsgWYAPeY7RQMn16tKrlQaBnpKv7KBfs4EQag==",
 			"dev": true,
 			"dependencies": {
-				"@typescript-eslint/types": "4.29.1",
+				"@typescript-eslint/types": "4.29.2",
 				"eslint-visitor-keys": "^2.0.0"
 			},
 			"engines": {
@@ -3677,15 +3677,15 @@
 			}
 		},
 		"node_modules/@vue/compiler-core": {
-			"version": "3.2.1",
-			"resolved": "https://registry.npmjs.org/@vue/compiler-core/-/compiler-core-3.2.1.tgz",
-			"integrity": "sha512-UEJf2ZGww5wGVdrWIXIZo04KdJFGPmI2bHRUsBZ3AdyCAqJ5ykRXKOBn1OR1hvA2YzimudOEyHM+DpbBv91Kww==",
+			"version": "3.2.4",
+			"resolved": "https://registry.npmjs.org/@vue/compiler-core/-/compiler-core-3.2.4.tgz",
+			"integrity": "sha512-c8NuQq7mUXXxA4iqD5VUKpyVeklK53+DMbojYMyZ0VPPrb0BUWrZWFiqSDT+MFDv0f6Hv3QuLiHWb1BWMXBbrw==",
 			"dev": true,
 			"optional": true,
 			"dependencies": {
 				"@babel/parser": "^7.12.0",
 				"@babel/types": "^7.12.0",
-				"@vue/shared": "3.2.1",
+				"@vue/shared": "3.2.4",
 				"estree-walker": "^2.0.1",
 				"source-map": "^0.6.1"
 			}
@@ -3701,30 +3701,30 @@
 			}
 		},
 		"node_modules/@vue/compiler-dom": {
-			"version": "3.2.1",
-			"resolved": "https://registry.npmjs.org/@vue/compiler-dom/-/compiler-dom-3.2.1.tgz",
-			"integrity": "sha512-tXg8tkPb3j54zNfWqoao9T1JI41yWPz8TROzmif/QNNA46eq8/SRuRsBd36i47GWaz7mh+yg3vOJ87/YBjcMyQ==",
+			"version": "3.2.4",
+			"resolved": "https://registry.npmjs.org/@vue/compiler-dom/-/compiler-dom-3.2.4.tgz",
+			"integrity": "sha512-uj1nwO4794fw2YsYas5QT+FU/YGrXbS0Qk+1c7Kp1kV7idhZIghWLTjyvYibpGoseFbYLPd+sW2/noJG5H04EQ==",
 			"dev": true,
 			"optional": true,
 			"dependencies": {
-				"@vue/compiler-core": "3.2.1",
-				"@vue/shared": "3.2.1"
+				"@vue/compiler-core": "3.2.4",
+				"@vue/shared": "3.2.4"
 			}
 		},
 		"node_modules/@vue/compiler-sfc": {
-			"version": "3.2.1",
-			"resolved": "https://registry.npmjs.org/@vue/compiler-sfc/-/compiler-sfc-3.2.1.tgz",
-			"integrity": "sha512-fVLdme5RZVkBt+jxv2LCSRM72o4FX7BR2eu2FpjjEi1kEtUMKBDnjKwGWy7TyhTju0t0CocctyoM+G56vH7NpQ==",
+			"version": "3.2.4",
+			"resolved": "https://registry.npmjs.org/@vue/compiler-sfc/-/compiler-sfc-3.2.4.tgz",
+			"integrity": "sha512-GM+ouDdDzhqgkLmBH4bgq4kiZxJQArSppJiZHWHIx9XRaefHLmc1LBNPmN8ivm4SVfi2i7M2t9k8ZnjsScgzPQ==",
 			"dev": true,
 			"optional": true,
 			"dependencies": {
 				"@babel/parser": "^7.13.9",
 				"@babel/types": "^7.13.0",
 				"@types/estree": "^0.0.48",
-				"@vue/compiler-core": "3.2.1",
-				"@vue/compiler-dom": "3.2.1",
-				"@vue/compiler-ssr": "3.2.1",
-				"@vue/shared": "3.2.1",
+				"@vue/compiler-core": "3.2.4",
+				"@vue/compiler-dom": "3.2.4",
+				"@vue/compiler-ssr": "3.2.4",
+				"@vue/shared": "3.2.4",
 				"consolidate": "^0.16.0",
 				"estree-walker": "^2.0.1",
 				"hash-sum": "^2.0.0",
@@ -3765,20 +3765,20 @@
 			"optional": true
 		},
 		"node_modules/@vue/compiler-ssr": {
-			"version": "3.2.1",
-			"resolved": "https://registry.npmjs.org/@vue/compiler-ssr/-/compiler-ssr-3.2.1.tgz",
-			"integrity": "sha512-6YAOtQunuEyYlVSjK1F7a7BXi7rxVfiTiJ0Ro7eq0q0MNCFV9Z+sN68lfa/E4ABVb0ledEY/Rt8kL23nwCoTCQ==",
+			"version": "3.2.4",
+			"resolved": "https://registry.npmjs.org/@vue/compiler-ssr/-/compiler-ssr-3.2.4.tgz",
+			"integrity": "sha512-bKZuXu9/4XwsFHFWIKQK+5kN7mxIIWmMmT2L4VVek7cvY/vm3p4WTsXYDGZJy0htOTXvM2ifr6sflg012T0hsw==",
 			"dev": true,
 			"optional": true,
 			"dependencies": {
-				"@vue/compiler-dom": "3.2.1",
-				"@vue/shared": "3.2.1"
+				"@vue/compiler-dom": "3.2.4",
+				"@vue/shared": "3.2.4"
 			}
 		},
 		"node_modules/@vue/shared": {
-			"version": "3.2.1",
-			"resolved": "https://registry.npmjs.org/@vue/shared/-/shared-3.2.1.tgz",
-			"integrity": "sha512-INN92dVBNgd0TW9BqfQQKx/HWGCHhUUbAV5EZ5FgSCiEdwuZsJbGt1mdnaD9IxGhpiyOjP2ClxGG8SFp7ELcWg==",
+			"version": "3.2.4",
+			"resolved": "https://registry.npmjs.org/@vue/shared/-/shared-3.2.4.tgz",
+			"integrity": "sha512-j2j1MRmjalVKr3YBTxl/BClSIc8UQ8NnPpLYclxerK65JIowI4O7n8O8lElveEtEoHxy1d7BelPUDI0Q4bumqg==",
 			"dev": true,
 			"optional": true
 		},
@@ -4140,19 +4140,6 @@
 				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
-		"node_modules/@wordpress/eslint-plugin/node_modules/prettier": {
-			"name": "wp-prettier",
-			"version": "2.2.1-beta-1",
-			"resolved": "https://registry.npmjs.org/wp-prettier/-/wp-prettier-2.2.1-beta-1.tgz",
-			"integrity": "sha512-+JHkqs9LC/JPp51yy1hzs3lQ7qeuWCwOcSzpQNeeY/G7oSpnF61vxt7hRh87zNRTr6ob2ndy0W8rVzhgrcA+Gw==",
-			"dev": true,
-			"bin": {
-				"prettier": "bin-prettier.js"
-			},
-			"engines": {
-				"node": ">=10.13.0"
-			}
-		},
 		"node_modules/@wordpress/eslint-plugin/node_modules/type-fest": {
 			"version": "0.8.1",
 			"resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.8.1.tgz",
@@ -4355,19 +4342,6 @@
 			"dev": true,
 			"engines": {
 				"node": ">=8"
-			}
-		},
-		"node_modules/@wordpress/scripts/node_modules/prettier": {
-			"name": "wp-prettier",
-			"version": "2.2.1-beta-1",
-			"resolved": "https://registry.npmjs.org/wp-prettier/-/wp-prettier-2.2.1-beta-1.tgz",
-			"integrity": "sha512-+JHkqs9LC/JPp51yy1hzs3lQ7qeuWCwOcSzpQNeeY/G7oSpnF61vxt7hRh87zNRTr6ob2ndy0W8rVzhgrcA+Gw==",
-			"dev": true,
-			"bin": {
-				"prettier": "bin-prettier.js"
-			},
-			"engines": {
-				"node": ">=10.13.0"
 			}
 		},
 		"node_modules/@wordpress/scripts/node_modules/supports-color": {
@@ -4923,14 +4897,14 @@
 			}
 		},
 		"node_modules/autoprefixer": {
-			"version": "10.3.1",
-			"resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-10.3.1.tgz",
-			"integrity": "sha512-L8AmtKzdiRyYg7BUXJTzigmhbQRCXFKz6SA1Lqo0+AR2FBbQ4aTAPFSDlOutnFkjhiz8my4agGXog1xlMjPJ6A==",
+			"version": "10.3.2",
+			"resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-10.3.2.tgz",
+			"integrity": "sha512-RHKq0YCvhxAn9987n0Gl6lkzLd39UKwCkUPMFE0cHhxU0SvcTjBxWG/CtkZ4/HvbqK9U5V8j03nAcGBlX3er/Q==",
 			"dev": true,
 			"dependencies": {
-				"browserslist": "^4.16.6",
-				"caniuse-lite": "^1.0.30001243",
-				"colorette": "^1.2.2",
+				"browserslist": "^4.16.8",
+				"caniuse-lite": "^1.0.30001251",
+				"colorette": "^1.3.0",
 				"fraction.js": "^4.1.1",
 				"normalize-range": "^0.1.2",
 				"postcss-value-parser": "^4.1.0"
@@ -5288,6 +5262,18 @@
 				"@babel/core": "^7.0.0"
 			}
 		},
+		"node_modules/babelify": {
+			"version": "10.0.0",
+			"resolved": "https://registry.npmjs.org/babelify/-/babelify-10.0.0.tgz",
+			"integrity": "sha512-X40FaxyH7t3X+JFAKvb1H9wooWKLRCi8pg3m8poqtdZaIng+bjzp9RvKQCvRjF9isHiPkXspbbXT/zwXLtwgwg==",
+			"dev": true,
+			"engines": {
+				"node": ">=6.9.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^7.0.0"
+			}
+		},
 		"node_modules/bail": {
 			"version": "1.0.5",
 			"resolved": "https://registry.npmjs.org/bail/-/bail-1.0.5.tgz",
@@ -5613,16 +5599,16 @@
 			}
 		},
 		"node_modules/browserslist": {
-			"version": "4.16.7",
-			"resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.16.7.tgz",
-			"integrity": "sha512-7I4qVwqZltJ7j37wObBe3SoTz+nS8APaNcrBOlgoirb6/HbEU2XxW/LpUDTCngM6iauwFqmRTuOMfyKnFGY5JA==",
+			"version": "4.16.8",
+			"resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.16.8.tgz",
+			"integrity": "sha512-sc2m9ohR/49sWEbPj14ZSSZqp+kbi16aLao42Hmn3Z8FpjuMaq2xCA2l4zl9ITfyzvnvyE0hcg62YkIGKxgaNQ==",
 			"dev": true,
 			"dependencies": {
-				"caniuse-lite": "^1.0.30001248",
-				"colorette": "^1.2.2",
-				"electron-to-chromium": "^1.3.793",
+				"caniuse-lite": "^1.0.30001251",
+				"colorette": "^1.3.0",
+				"electron-to-chromium": "^1.3.811",
 				"escalade": "^3.1.1",
-				"node-releases": "^1.1.73"
+				"node-releases": "^1.1.75"
 			},
 			"bin": {
 				"browserslist": "cli.js"
@@ -5900,9 +5886,9 @@
 			}
 		},
 		"node_modules/caniuse-lite": {
-			"version": "1.0.30001249",
-			"resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001249.tgz",
-			"integrity": "sha512-vcX4U8lwVXPdqzPWi6cAJ3FnQaqXbBqy/GZseKNQzRj37J7qZdGcBtxq/QLFNLLlfsoXLUdHw8Iwenri86Tagw==",
+			"version": "1.0.30001251",
+			"resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001251.tgz",
+			"integrity": "sha512-HOe1r+9VkU4TFmnU70z+r7OLmtR+/chB1rdcJUeQlAinjEeb0cKL20tlAtOagNZhbrtLnCvV19B4FmF1rgzl6A==",
 			"dev": true,
 			"funding": {
 				"type": "opencollective",
@@ -6877,13 +6863,13 @@
 			}
 		},
 		"node_modules/conventional-changelog-core/node_modules/normalize-package-data": {
-			"version": "3.0.2",
-			"resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-3.0.2.tgz",
-			"integrity": "sha512-6CdZocmfGaKnIHPVFhJJZ3GuR8SsLKvDANFp47Jmy51aKIr8akjAWTSxtpI+MBgBFdSMRyo4hMpDlT6dTffgZg==",
+			"version": "3.0.3",
+			"resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-3.0.3.tgz",
+			"integrity": "sha512-p2W1sgqij3zMMyRC067Dg16bfzVH+w7hyegmpIvZ4JNjqtGOVAIvLmjBx3yP7YTe9vKJgkoNOPjwQGogDoMXFA==",
 			"dev": true,
 			"dependencies": {
 				"hosted-git-info": "^4.0.1",
-				"resolve": "^1.20.0",
+				"is-core-module": "^2.5.0",
 				"semver": "^7.3.4",
 				"validate-npm-package-license": "^3.0.1"
 			},
@@ -7217,13 +7203,13 @@
 			}
 		},
 		"node_modules/conventional-changelog-writer/node_modules/normalize-package-data": {
-			"version": "3.0.2",
-			"resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-3.0.2.tgz",
-			"integrity": "sha512-6CdZocmfGaKnIHPVFhJJZ3GuR8SsLKvDANFp47Jmy51aKIr8akjAWTSxtpI+MBgBFdSMRyo4hMpDlT6dTffgZg==",
+			"version": "3.0.3",
+			"resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-3.0.3.tgz",
+			"integrity": "sha512-p2W1sgqij3zMMyRC067Dg16bfzVH+w7hyegmpIvZ4JNjqtGOVAIvLmjBx3yP7YTe9vKJgkoNOPjwQGogDoMXFA==",
 			"dev": true,
 			"dependencies": {
 				"hosted-git-info": "^4.0.1",
-				"resolve": "^1.20.0",
+				"is-core-module": "^2.5.0",
 				"semver": "^7.3.4",
 				"validate-npm-package-license": "^3.0.1"
 			},
@@ -7457,13 +7443,13 @@
 			}
 		},
 		"node_modules/conventional-commits-parser/node_modules/normalize-package-data": {
-			"version": "3.0.2",
-			"resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-3.0.2.tgz",
-			"integrity": "sha512-6CdZocmfGaKnIHPVFhJJZ3GuR8SsLKvDANFp47Jmy51aKIr8akjAWTSxtpI+MBgBFdSMRyo4hMpDlT6dTffgZg==",
+			"version": "3.0.3",
+			"resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-3.0.3.tgz",
+			"integrity": "sha512-p2W1sgqij3zMMyRC067Dg16bfzVH+w7hyegmpIvZ4JNjqtGOVAIvLmjBx3yP7YTe9vKJgkoNOPjwQGogDoMXFA==",
 			"dev": true,
 			"dependencies": {
 				"hosted-git-info": "^4.0.1",
-				"resolve": "^1.20.0",
+				"is-core-module": "^2.5.0",
 				"semver": "^7.3.4",
 				"validate-npm-package-license": "^3.0.1"
 			},
@@ -7700,13 +7686,13 @@
 			}
 		},
 		"node_modules/conventional-recommended-bump/node_modules/normalize-package-data": {
-			"version": "3.0.2",
-			"resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-3.0.2.tgz",
-			"integrity": "sha512-6CdZocmfGaKnIHPVFhJJZ3GuR8SsLKvDANFp47Jmy51aKIr8akjAWTSxtpI+MBgBFdSMRyo4hMpDlT6dTffgZg==",
+			"version": "3.0.3",
+			"resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-3.0.3.tgz",
+			"integrity": "sha512-p2W1sgqij3zMMyRC067Dg16bfzVH+w7hyegmpIvZ4JNjqtGOVAIvLmjBx3yP7YTe9vKJgkoNOPjwQGogDoMXFA==",
 			"dev": true,
 			"dependencies": {
 				"hosted-git-info": "^4.0.1",
-				"resolve": "^1.20.0",
+				"is-core-module": "^2.5.0",
 				"semver": "^7.3.4",
 				"validate-npm-package-license": "^3.0.1"
 			},
@@ -7880,9 +7866,9 @@
 			}
 		},
 		"node_modules/core-js": {
-			"version": "3.16.1",
-			"resolved": "https://registry.npmjs.org/core-js/-/core-js-3.16.1.tgz",
-			"integrity": "sha512-AAkP8i35EbefU+JddyWi12AWE9f2N/qr/pwnDtWz4nyUIBGMJPX99ANFFRSw6FefM374lDujdtLDyhN2A/btHw==",
+			"version": "3.16.2",
+			"resolved": "https://registry.npmjs.org/core-js/-/core-js-3.16.2.tgz",
+			"integrity": "sha512-P0KPukO6OjMpjBtHSceAZEWlDD1M2Cpzpg6dBbrjFqFhBHe/BwhxaP820xKOjRn/lZRQirrCusIpLS/n2sgXLQ==",
 			"dev": true,
 			"hasInstallScript": true,
 			"funding": {
@@ -7891,9 +7877,9 @@
 			}
 		},
 		"node_modules/core-js-compat": {
-			"version": "3.16.1",
-			"resolved": "https://registry.npmjs.org/core-js-compat/-/core-js-compat-3.16.1.tgz",
-			"integrity": "sha512-NHXQXvRbd4nxp9TEmooTJLUf94ySUG6+DSsscBpTftN1lQLQ4LjnWvc7AoIo4UjDsFF3hB8Uh5LLCRRdaiT5MQ==",
+			"version": "3.16.2",
+			"resolved": "https://registry.npmjs.org/core-js-compat/-/core-js-compat-3.16.2.tgz",
+			"integrity": "sha512-4lUshXtBXsdmp8cDWh6KKiHUg40AjiuPD3bOWkNVsr1xkAhpUqCjaZ8lB1bKx9Gb5fXcbRbFJ4f4qpRIRTuJqQ==",
 			"dev": true,
 			"dependencies": {
 				"browserslist": "^4.16.7",
@@ -7914,9 +7900,9 @@
 			}
 		},
 		"node_modules/core-js-pure": {
-			"version": "3.16.1",
-			"resolved": "https://registry.npmjs.org/core-js-pure/-/core-js-pure-3.16.1.tgz",
-			"integrity": "sha512-TyofCdMzx0KMhi84mVRS8rL1XsRk2SPUNz2azmth53iRN0/08Uim9fdhQTaZTG1LqaXHYVci4RDHka6WrXfnvg==",
+			"version": "3.16.2",
+			"resolved": "https://registry.npmjs.org/core-js-pure/-/core-js-pure-3.16.2.tgz",
+			"integrity": "sha512-oxKe64UH049mJqrKkynWp6Vu0Rlm/BTXO/bJZuN2mmR3RtOFNepLlSWDd1eo16PzHpQAoNG97rLU1V/YxesJjw==",
 			"dev": true,
 			"hasInstallScript": true,
 			"funding": {
@@ -7931,9 +7917,9 @@
 			"dev": true
 		},
 		"node_modules/cosmiconfig": {
-			"version": "7.0.0",
-			"resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-7.0.0.tgz",
-			"integrity": "sha512-pondGvTuVYDk++upghXJabWzL6Kxu6f26ljFw64Swq9v6sQPUL3EUlVDV56diOjpCayKihL6hVe8exIACU4XcA==",
+			"version": "7.0.1",
+			"resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-7.0.1.tgz",
+			"integrity": "sha512-a1YWNUV2HwGimB7dU2s1wUMurNKjpx60HxBB6xUM8Re+2s1g1IIfJvFR0/iCF+XHdE0GMTKTuLR32UQff4TEyQ==",
 			"dev": true,
 			"dependencies": {
 				"@types/parse-json": "^4.0.0",
@@ -8825,18 +8811,6 @@
 				"node": ">=6.0.0"
 			}
 		},
-		"node_modules/documentation/node_modules/babelify": {
-			"version": "10.0.0",
-			"resolved": "https://registry.npmjs.org/babelify/-/babelify-10.0.0.tgz",
-			"integrity": "sha512-X40FaxyH7t3X+JFAKvb1H9wooWKLRCi8pg3m8poqtdZaIng+bjzp9RvKQCvRjF9isHiPkXspbbXT/zwXLtwgwg==",
-			"dev": true,
-			"engines": {
-				"node": ">=6.9.0"
-			},
-			"peerDependencies": {
-				"@babel/core": "^7.0.0"
-			}
-		},
 		"node_modules/documentation/node_modules/find-up": {
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/find-up/-/find-up-3.0.0.tgz",
@@ -9193,9 +9167,9 @@
 			}
 		},
 		"node_modules/electron-to-chromium": {
-			"version": "1.3.802",
-			"resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.802.tgz",
-			"integrity": "sha512-dXB0SGSypfm3iEDxrb5n/IVKeX4uuTnFHdve7v+yKJqNpEP0D4mjFJ8e1znmSR+OOVlVC+kDO6f2kAkTFXvJBg==",
+			"version": "1.3.814",
+			"resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.814.tgz",
+			"integrity": "sha512-0mH03cyjh6OzMlmjauGg0TLd87ErIJqWiYxMcOLKf5w6p0YEOl7DJAj7BDlXEFmCguY5CQaKVOiMjAMODO2XDw==",
 			"dev": true
 		},
 		"node_modules/elliptic": {
@@ -9636,9 +9610,9 @@
 			}
 		},
 		"node_modules/eslint-import-resolver-node": {
-			"version": "0.3.5",
-			"resolved": "https://registry.npmjs.org/eslint-import-resolver-node/-/eslint-import-resolver-node-0.3.5.tgz",
-			"integrity": "sha512-XMoPKjSpXbkeJ7ZZ9icLnJMTY5Mc1kZbCakHquaFsXPpyWOwK0TK6CODO+0ca54UoM9LKOxyUNnoVZRl8TeaAg==",
+			"version": "0.3.6",
+			"resolved": "https://registry.npmjs.org/eslint-import-resolver-node/-/eslint-import-resolver-node-0.3.6.tgz",
+			"integrity": "sha512-0En0w03NRVMn9Uiyn8YRPDKvWjxCWkslUEhGNTdGx15RvPJYQ+lbOlqrlNI2vEAs4pDYK4f/HN2TbDmk5TP0iw==",
 			"dev": true,
 			"dependencies": {
 				"debug": "^3.2.7",
@@ -9677,26 +9651,26 @@
 			}
 		},
 		"node_modules/eslint-plugin-import": {
-			"version": "2.24.0",
-			"resolved": "https://registry.npmjs.org/eslint-plugin-import/-/eslint-plugin-import-2.24.0.tgz",
-			"integrity": "sha512-Kc6xqT9hiYi2cgybOc0I2vC9OgAYga5o/rAFinam/yF/t5uBqxQbauNPMC6fgb640T/89P0gFoO27FOilJ/Cqg==",
+			"version": "2.24.1",
+			"resolved": "https://registry.npmjs.org/eslint-plugin-import/-/eslint-plugin-import-2.24.1.tgz",
+			"integrity": "sha512-KSFWhNxPH8OGJwpRJJs+Z7I0a13E2iFQZJIvSnCu6KUs4qmgAm3xN9GYBCSoiGWmwA7gERZPXqYQjcoCROnYhQ==",
 			"dev": true,
 			"dependencies": {
 				"array-includes": "^3.1.3",
 				"array.prototype.flat": "^1.2.4",
 				"debug": "^2.6.9",
 				"doctrine": "^2.1.0",
-				"eslint-import-resolver-node": "^0.3.5",
+				"eslint-import-resolver-node": "^0.3.6",
 				"eslint-module-utils": "^2.6.2",
 				"find-up": "^2.0.0",
 				"has": "^1.0.3",
-				"is-core-module": "^2.4.0",
+				"is-core-module": "^2.6.0",
 				"minimatch": "^3.0.4",
-				"object.values": "^1.1.3",
+				"object.values": "^1.1.4",
 				"pkg-up": "^2.0.0",
 				"read-pkg-up": "^3.0.0",
 				"resolve": "^1.20.0",
-				"tsconfig-paths": "^3.9.0"
+				"tsconfig-paths": "^3.10.1"
 			},
 			"engines": {
 				"node": ">=4"
@@ -10002,9 +9976,9 @@
 			}
 		},
 		"node_modules/eslint-plugin-prettier": {
-			"version": "3.4.0",
-			"resolved": "https://registry.npmjs.org/eslint-plugin-prettier/-/eslint-plugin-prettier-3.4.0.tgz",
-			"integrity": "sha512-UDK6rJT6INSfcOo545jiaOwB701uAIt2/dR7WnFQoGCVl1/EMqdANBmwUaqqQ45aXprsTGzSa39LI1PyuRBxxw==",
+			"version": "3.4.1",
+			"resolved": "https://registry.npmjs.org/eslint-plugin-prettier/-/eslint-plugin-prettier-3.4.1.tgz",
+			"integrity": "sha512-htg25EUYUeIhKHXjOinK4BgCcDwtLHjqaxCDsMy5nbnUMkKFvIhMVCp+5GFUXQ4Nr8lBsPqtGAqBenbpFqAA2g==",
 			"dev": true,
 			"dependencies": {
 				"prettier-linter-helpers": "^1.0.0"
@@ -10234,9 +10208,9 @@
 			}
 		},
 		"node_modules/eslint/node_modules/globals": {
-			"version": "13.10.0",
-			"resolved": "https://registry.npmjs.org/globals/-/globals-13.10.0.tgz",
-			"integrity": "sha512-piHC3blgLGFjvOuMmWZX60f+na1lXFDhQXBf1UYp2fXPXqvEUbOhNwi6BsQ0bQishwedgnjkwv1d9zKf+MWw3g==",
+			"version": "13.11.0",
+			"resolved": "https://registry.npmjs.org/globals/-/globals-13.11.0.tgz",
+			"integrity": "sha512-08/xrJ7wQjK9kkkRoI3OFUBbLx4f+6x3SGwcPvQ0QH6goFDrOU2oyAWrmh3dJezu65buo+HBMzAMQy6rovVC3g==",
 			"dev": true,
 			"dependencies": {
 				"type-fest": "^0.20.2"
@@ -10927,9 +10901,9 @@
 			"dev": true
 		},
 		"node_modules/fastq": {
-			"version": "1.11.1",
-			"resolved": "https://registry.npmjs.org/fastq/-/fastq-1.11.1.tgz",
-			"integrity": "sha512-HOnr8Mc60eNYl1gzwp6r5RoUyAn5/glBolUzP/Ez6IFVPMPirxn/9phgL6zhOtaTy7ISwPvQ+wT+hfcRZh/bzw==",
+			"version": "1.12.0",
+			"resolved": "https://registry.npmjs.org/fastq/-/fastq-1.12.0.tgz",
+			"integrity": "sha512-VNX0QkHK3RsXVKr9KrlUv/FoTa0NdbYoHHl7uXHv2rzyHSlxjdNAKug2twd9luJxpcyNeAgf5iPPMutJO67Dfg==",
 			"dev": true,
 			"dependencies": {
 				"reusify": "^1.0.4"
@@ -11942,13 +11916,13 @@
 			}
 		},
 		"node_modules/git-raw-commits/node_modules/normalize-package-data": {
-			"version": "3.0.2",
-			"resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-3.0.2.tgz",
-			"integrity": "sha512-6CdZocmfGaKnIHPVFhJJZ3GuR8SsLKvDANFp47Jmy51aKIr8akjAWTSxtpI+MBgBFdSMRyo4hMpDlT6dTffgZg==",
+			"version": "3.0.3",
+			"resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-3.0.3.tgz",
+			"integrity": "sha512-p2W1sgqij3zMMyRC067Dg16bfzVH+w7hyegmpIvZ4JNjqtGOVAIvLmjBx3yP7YTe9vKJgkoNOPjwQGogDoMXFA==",
 			"dev": true,
 			"dependencies": {
 				"hosted-git-info": "^4.0.1",
-				"resolve": "^1.20.0",
+				"is-core-module": "^2.5.0",
 				"semver": "^7.3.4",
 				"validate-npm-package-license": "^3.0.1"
 			},
@@ -12186,13 +12160,13 @@
 			}
 		},
 		"node_modules/git-semver-tags/node_modules/normalize-package-data": {
-			"version": "3.0.2",
-			"resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-3.0.2.tgz",
-			"integrity": "sha512-6CdZocmfGaKnIHPVFhJJZ3GuR8SsLKvDANFp47Jmy51aKIr8akjAWTSxtpI+MBgBFdSMRyo4hMpDlT6dTffgZg==",
+			"version": "3.0.3",
+			"resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-3.0.3.tgz",
+			"integrity": "sha512-p2W1sgqij3zMMyRC067Dg16bfzVH+w7hyegmpIvZ4JNjqtGOVAIvLmjBx3yP7YTe9vKJgkoNOPjwQGogDoMXFA==",
 			"dev": true,
 			"dependencies": {
 				"hosted-git-info": "^4.0.1",
-				"resolve": "^1.20.0",
+				"is-core-module": "^2.5.0",
 				"semver": "^7.3.4",
 				"validate-npm-package-license": "^3.0.1"
 			},
@@ -13335,10 +13309,13 @@
 			"dev": true
 		},
 		"node_modules/is-bigint": {
-			"version": "1.0.3",
-			"resolved": "https://registry.npmjs.org/is-bigint/-/is-bigint-1.0.3.tgz",
-			"integrity": "sha512-ZU538ajmYJmzysE5yU4Y7uIrPQ2j704u+hXFiIPQExpqzzUbpe5jCPdTfmz7jXRxZdvjY3KZ3ZNenoXQovX+Dg==",
+			"version": "1.0.4",
+			"resolved": "https://registry.npmjs.org/is-bigint/-/is-bigint-1.0.4.tgz",
+			"integrity": "sha512-zB9CruMamjym81i2JZ3UMn54PKGsQzsJeo6xvN3HJJ4CAsQNB6iRutp2To77OfCNuoxspsIhzaPoO1zyCEhFOg==",
 			"dev": true,
+			"dependencies": {
+				"has-bigints": "^1.0.1"
+			},
 			"funding": {
 				"url": "https://github.com/sponsors/ljharb"
 			}
@@ -13403,9 +13380,9 @@
 			}
 		},
 		"node_modules/is-core-module": {
-			"version": "2.5.0",
-			"resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.5.0.tgz",
-			"integrity": "sha512-TXCMSDsEHMEEZ6eCA8rwRDbLu55MRGmrctljsBX/2v1d9/GzqHOxW5c5oPSgrUt2vBFXebu9rGqckXGPWOlYpg==",
+			"version": "2.6.0",
+			"resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.6.0.tgz",
+			"integrity": "sha512-wShG8vs60jKfPWpF2KZRaAtvt3a20OAn7+IJ6hLPECpSABLcKtFKTTI4ZtH5QcBruBHlq+WsdHWyz0BCZW7svQ==",
 			"dev": true,
 			"dependencies": {
 				"has": "^1.0.3"
@@ -18301,9 +18278,9 @@
 			"optional": true
 		},
 		"node_modules/nanoid": {
-			"version": "3.1.23",
-			"resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.1.23.tgz",
-			"integrity": "sha512-FiB0kzdP0FFVGDKlRLEQ1BgDzU87dy5NnzjeW9YZNt+/c3+q82EQDUwniSAUxp/F0gFNI1ZhKU1FqYsMuqZVnw==",
+			"version": "3.1.25",
+			"resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.1.25.tgz",
+			"integrity": "sha512-rdwtIXaXCLFAQbnfqDRnI6jaRHp9fTcYBjtFKE8eezcZ7LuLjhUaQGNeMXf1HmRoCH32CLz6XwX0TtxEOS/A3Q==",
 			"dev": true,
 			"bin": {
 				"nanoid": "bin/nanoid.cjs"
@@ -18554,9 +18531,9 @@
 			"optional": true
 		},
 		"node_modules/node-releases": {
-			"version": "1.1.74",
-			"resolved": "https://registry.npmjs.org/node-releases/-/node-releases-1.1.74.tgz",
-			"integrity": "sha512-caJBVempXZPepZoZAPCWRTNxYQ+xtG/KAi4ozTA5A+nJ7IU+kLQCbqaUjb5Rwy14M9upBWiQ4NutcmW04LJSRw==",
+			"version": "1.1.75",
+			"resolved": "https://registry.npmjs.org/node-releases/-/node-releases-1.1.75.tgz",
+			"integrity": "sha512-Qe5OUajvqrqDSy6wrWFmMwfJ0jVgwiw4T3KqmbTcZ62qW0gQkheXYhcFM1+lOVcGUoRxcEcfyvFMAnDgaF1VWw==",
 			"dev": true
 		},
 		"node_modules/normalize-package-data": {
@@ -18629,14 +18606,14 @@
 			}
 		},
 		"node_modules/npm-package-json-lint": {
-			"version": "5.2.2",
-			"resolved": "https://registry.npmjs.org/npm-package-json-lint/-/npm-package-json-lint-5.2.2.tgz",
-			"integrity": "sha512-rs+mTLK31dRHzOrPcA33VoVgPxib0WecKGKOm6XkE186/FqiZGmGgkNLpxx1baUORkSmU1ETyi7aQXlZUzqZIA==",
+			"version": "5.2.3",
+			"resolved": "https://registry.npmjs.org/npm-package-json-lint/-/npm-package-json-lint-5.2.3.tgz",
+			"integrity": "sha512-rSgc4eVhtfwrU7AWwovqFWy8OEkgQL99vD3vWJmqtU9gxxJxKzi6Wqgo3gF7lhrBpyVcnlKxy/L2JCsvjWruDA==",
 			"dev": true,
 			"dependencies": {
 				"ajv": "^6.12.6",
 				"ajv-errors": "^1.0.1",
-				"chalk": "^4.1.1",
+				"chalk": "^4.1.2",
 				"cosmiconfig": "^6.0.0",
 				"debug": "^4.3.2",
 				"globby": "^11.0.4",
@@ -20289,11 +20266,11 @@
 			}
 		},
 		"node_modules/prettier": {
-			"version": "2.3.2",
-			"resolved": "https://registry.npmjs.org/prettier/-/prettier-2.3.2.tgz",
-			"integrity": "sha512-lnJzDfJ66zkMy58OL5/NY5zp70S7Nz6KqcKkXYzn2tMVrNxvbqaBpg7H3qHaLxCJ5lNMsGuM8+ohS7cZrthdLQ==",
+			"name": "wp-prettier",
+			"version": "2.2.1-beta-1",
+			"resolved": "https://registry.npmjs.org/wp-prettier/-/wp-prettier-2.2.1-beta-1.tgz",
+			"integrity": "sha512-+JHkqs9LC/JPp51yy1hzs3lQ7qeuWCwOcSzpQNeeY/G7oSpnF61vxt7hRh87zNRTr6ob2ndy0W8rVzhgrcA+Gw==",
 			"dev": true,
-			"peer": true,
 			"bin": {
 				"prettier": "bin-prettier.js"
 			},
@@ -21730,9 +21707,9 @@
 			}
 		},
 		"node_modules/sass": {
-			"version": "1.37.5",
-			"resolved": "https://registry.npmjs.org/sass/-/sass-1.37.5.tgz",
-			"integrity": "sha512-Cx3ewxz9QB/ErnVIiWg2cH0kiYZ0FPvheDTVC6BsiEGBTZKKZJ1Gq5Kq6jy3PKtL6+EJ8NIoaBW/RSd2R6cZOA==",
+			"version": "1.38.0",
+			"resolved": "https://registry.npmjs.org/sass/-/sass-1.38.0.tgz",
+			"integrity": "sha512-WBccZeMigAGKoI+NgD7Adh0ab1HUq+6BmyBUEaGxtErbUtWUevEbdgo5EZiJQofLUGcKtlNaO2IdN73AHEua5g==",
 			"dev": true,
 			"dependencies": {
 				"chokidar": ">=3.0.0 <4.0.0"
@@ -22026,12 +22003,12 @@
 			"dev": true
 		},
 		"node_modules/sirv": {
-			"version": "1.0.12",
-			"resolved": "https://registry.npmjs.org/sirv/-/sirv-1.0.12.tgz",
-			"integrity": "sha512-+jQoCxndz7L2tqQL4ZyzfDhky0W/4ZJip3XoOuxyQWnAwMxindLl3Xv1qT4x1YX/re0leShvTm8Uk0kQspGhBg==",
+			"version": "1.0.14",
+			"resolved": "https://registry.npmjs.org/sirv/-/sirv-1.0.14.tgz",
+			"integrity": "sha512-czTFDFjK9lXj0u9mJ3OmJoXFztoilYS+NdRPcJoT182w44wSEkHSiO7A2517GLJ8wKM4GjCm2OXE66Dhngbzjg==",
 			"dev": true,
 			"dependencies": {
-				"@polka/url": "^1.0.0-next.15",
+				"@polka/url": "^1.0.0-next.17",
 				"mime": "^2.3.1",
 				"totalist": "^1.0.0"
 			},
@@ -23475,13 +23452,13 @@
 			}
 		},
 		"node_modules/stylelint/node_modules/normalize-package-data": {
-			"version": "3.0.2",
-			"resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-3.0.2.tgz",
-			"integrity": "sha512-6CdZocmfGaKnIHPVFhJJZ3GuR8SsLKvDANFp47Jmy51aKIr8akjAWTSxtpI+MBgBFdSMRyo4hMpDlT6dTffgZg==",
+			"version": "3.0.3",
+			"resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-3.0.3.tgz",
+			"integrity": "sha512-p2W1sgqij3zMMyRC067Dg16bfzVH+w7hyegmpIvZ4JNjqtGOVAIvLmjBx3yP7YTe9vKJgkoNOPjwQGogDoMXFA==",
 			"dev": true,
 			"dependencies": {
 				"hosted-git-info": "^4.0.1",
-				"resolve": "^1.20.0",
+				"is-core-module": "^2.5.0",
 				"semver": "^7.3.4",
 				"validate-npm-package-license": "^3.0.1"
 			},
@@ -24048,9 +24025,9 @@
 			}
 		},
 		"node_modules/tar": {
-			"version": "6.1.7",
-			"resolved": "https://registry.npmjs.org/tar/-/tar-6.1.7.tgz",
-			"integrity": "sha512-PBoRkOJU0X3lejJ8GaRCsobjXTgFofRDSPdSUhRSdlwJfifRlQBwGXitDItdGFu0/h0XDMCkig0RN1iT7DBxhA==",
+			"version": "6.1.10",
+			"resolved": "https://registry.npmjs.org/tar/-/tar-6.1.10.tgz",
+			"integrity": "sha512-kvvfiVvjGMxeUNB6MyYv5z7vhfFRwbwCXJAeL0/lnbrttBVqcMOnpHUf0X42LrPMR8mMpgapkJMchFH4FSHzNA==",
 			"dev": true,
 			"dependencies": {
 				"chownr": "^2.0.0",
@@ -24595,9 +24572,9 @@
 			}
 		},
 		"node_modules/tslib": {
-			"version": "2.3.0",
-			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.0.tgz",
-			"integrity": "sha512-N82ooyxVNm6h1riLCoyS9e3fuJ3AMG2zIZs2Gd1ATcSFjSA23Q0fzjjZeh0jbJvWVDZ0cJT8yaNNaaXHzueNjg==",
+			"version": "2.3.1",
+			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
+			"integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw==",
 			"dev": true
 		},
 		"node_modules/tsutils": {
@@ -27053,14 +27030,14 @@
 			}
 		},
 		"@babel/helpers": {
-			"version": "7.14.8",
-			"resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.14.8.tgz",
-			"integrity": "sha512-ZRDmI56pnV+p1dH6d+UN6GINGz7Krps3+270qqI9UJ4wxYThfAIcI5i7j5vXC4FJ3Wap+S9qcebxeYiqn87DZw==",
+			"version": "7.15.3",
+			"resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.15.3.tgz",
+			"integrity": "sha512-HwJiz52XaS96lX+28Tnbu31VeFSQJGOeKHJeaEPQlTl7PnlhFElWPj8tUXtqFIzeN86XxXoBr+WFAyK2PPVz6g==",
 			"dev": true,
 			"requires": {
 				"@babel/template": "^7.14.5",
-				"@babel/traverse": "^7.14.8",
-				"@babel/types": "^7.14.8"
+				"@babel/traverse": "^7.15.0",
+				"@babel/types": "^7.15.0"
 			}
 		},
 		"@babel/highlight": {
@@ -27075,9 +27052,9 @@
 			}
 		},
 		"@babel/parser": {
-			"version": "7.15.2",
-			"resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.15.2.tgz",
-			"integrity": "sha512-bMJXql1Ss8lFnvr11TZDH4ArtwlAS5NG9qBmdiFW2UHHm6MVoR+GDc5XE2b9K938cyjc9O6/+vjjcffLDtfuDg==",
+			"version": "7.15.3",
+			"resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.15.3.tgz",
+			"integrity": "sha512-O0L6v/HvqbdJawj0iBEfVQMc3/6WP+AeOsovsIgBFyJaG+W2w7eqvZB7puddATmWuARlm1SX7DwxJ/JJUnDpEA==",
 			"dev": true
 		},
 		"@babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining": {
@@ -27441,9 +27418,9 @@
 			}
 		},
 		"@babel/plugin-transform-block-scoping": {
-			"version": "7.14.5",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-block-scoping/-/plugin-transform-block-scoping-7.14.5.tgz",
-			"integrity": "sha512-LBYm4ZocNgoCqyxMLoOnwpsmQ18HWTQvql64t3GvMUzLQrNoV1BDG0lNftC8QKYERkZgCCT/7J5xWGObGAyHDw==",
+			"version": "7.15.3",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-block-scoping/-/plugin-transform-block-scoping-7.15.3.tgz",
+			"integrity": "sha512-nBAzfZwZb4DkaGtOes1Up1nOAp9TDRRFw4XBzBBSG9QK7KVFmYzgj9o9sbPv7TX5ofL4Auq4wZnxCoPnI/lz2Q==",
 			"dev": true,
 			"requires": {
 				"@babel/helper-plugin-utils": "^7.14.5"
@@ -27918,17 +27895,17 @@
 			}
 		},
 		"@babel/runtime": {
-			"version": "7.14.8",
-			"resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.14.8.tgz",
-			"integrity": "sha512-twj3L8Og5SaCRCErB4x4ajbvBIVV77CGeFglHpeg5WC5FF8TZzBWXtTJ4MqaD9QszLYTtr+IsaAL2rEUevb+eg==",
+			"version": "7.15.3",
+			"resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.15.3.tgz",
+			"integrity": "sha512-OvwMLqNXkCXSz1kSm58sEsNuhqOx/fKpnUnKnFB5v8uDda5bLNEHNgKPvhDN6IU0LDcnHQ90LlJ0Q6jnyBSIBA==",
 			"requires": {
 				"regenerator-runtime": "^0.13.4"
 			}
 		},
 		"@babel/runtime-corejs3": {
-			"version": "7.14.9",
-			"resolved": "https://registry.npmjs.org/@babel/runtime-corejs3/-/runtime-corejs3-7.14.9.tgz",
-			"integrity": "sha512-64RiH2ON4/y8qYtoa8rUiyam/tUVyGqRyNYhe+vCRGmjnV4bUlZvY+mwd0RrmLoCpJpdq3RsrNqKb7SJdw/4kw==",
+			"version": "7.15.3",
+			"resolved": "https://registry.npmjs.org/@babel/runtime-corejs3/-/runtime-corejs3-7.15.3.tgz",
+			"integrity": "sha512-30A3lP+sRL6ml8uhoJSs+8jwpKzbw8CqBvDc1laeptxPm5FahumJxirigcbD2qTs71Sonvj1cyZB0OKGAmxQ+A==",
 			"dev": true,
 			"requires": {
 				"core-js-pure": "^3.16.0",
@@ -28018,9 +27995,9 @@
 			},
 			"dependencies": {
 				"globals": {
-					"version": "13.10.0",
-					"resolved": "https://registry.npmjs.org/globals/-/globals-13.10.0.tgz",
-					"integrity": "sha512-piHC3blgLGFjvOuMmWZX60f+na1lXFDhQXBf1UYp2fXPXqvEUbOhNwi6BsQ0bQishwedgnjkwv1d9zKf+MWw3g==",
+					"version": "13.11.0",
+					"resolved": "https://registry.npmjs.org/globals/-/globals-13.11.0.tgz",
+					"integrity": "sha512-08/xrJ7wQjK9kkkRoI3OFUBbLx4f+6x3SGwcPvQ0QH6goFDrOU2oyAWrmh3dJezu65buo+HBMzAMQy6rovVC3g==",
 					"dev": true,
 					"requires": {
 						"type-fest": "^0.20.2"
@@ -28789,9 +28766,9 @@
 			}
 		},
 		"@polka/url": {
-			"version": "1.0.0-next.15",
-			"resolved": "https://registry.npmjs.org/@polka/url/-/url-1.0.0-next.15.tgz",
-			"integrity": "sha512-15spi3V28QdevleWBNXE4pIls3nFZmBbUGrW9IVPwiQczuSb9n76TCB4bsk8TSel+I1OkHEdPhu5QKMfY6rQHA==",
+			"version": "1.0.0-next.17",
+			"resolved": "https://registry.npmjs.org/@polka/url/-/url-1.0.0-next.17.tgz",
+			"integrity": "sha512-0p1rCgM3LLbAdwBnc7gqgnvjHg9KpbhcSphergHShlkWz8EdPawoMJ3/VbezI0mGC5eKCDzMaPgF9Yca6cKvrg==",
 			"dev": true
 		},
 		"@sinonjs/commons": {
@@ -29067,9 +29044,9 @@
 			"dev": true
 		},
 		"@types/mdast": {
-			"version": "3.0.7",
-			"resolved": "https://registry.npmjs.org/@types/mdast/-/mdast-3.0.7.tgz",
-			"integrity": "sha512-YwR7OK8aPmaBvMMUi+pZXBNoW2unbVbfok4YRqGMJBe1dpDlzpRkJrYEYmvjxgs5JhuQmKfDexrN98u941Zasg==",
+			"version": "3.0.9",
+			"resolved": "https://registry.npmjs.org/@types/mdast/-/mdast-3.0.9.tgz",
+			"integrity": "sha512-IUlIhG2KNPjOEuXIblTjovD1XW8HPGeulA12nEyc6xhO4Yrrcs+xczAl4ucR3cpwVlE+vb2x9Z7pRmVP4bUHng==",
 			"dev": true,
 			"requires": {
 				"@types/unist": "*"
@@ -29088,9 +29065,9 @@
 			"dev": true
 		},
 		"@types/node": {
-			"version": "16.4.13",
-			"resolved": "https://registry.npmjs.org/@types/node/-/node-16.4.13.tgz",
-			"integrity": "sha512-bLL69sKtd25w7p1nvg9pigE4gtKVpGTPojBFLMkGHXuUgap2sLqQt2qUnqmVCDfzGUL0DRNZP+1prIZJbMeAXg==",
+			"version": "16.7.1",
+			"resolved": "https://registry.npmjs.org/@types/node/-/node-16.7.1.tgz",
+			"integrity": "sha512-ncRdc45SoYJ2H4eWU9ReDfp3vtFqDYhjOsKlFFUDEn8V1Bgr2RjYal8YT5byfadWIRluhPFU6JiDOl0H6Sl87A==",
 			"dev": true
 		},
 		"@types/normalize-package-data": {
@@ -29123,9 +29100,9 @@
 			"dev": true
 		},
 		"@types/react": {
-			"version": "16.14.12",
-			"resolved": "https://registry.npmjs.org/@types/react/-/react-16.14.12.tgz",
-			"integrity": "sha512-7nOJgNsRbARhZhvwPm7cnzahtzEi5VJ9OvcQk8ExEEb1t+zaFklwLVkJz7G1kfxX4X/mDa/icTmzE0vTmqsqBg==",
+			"version": "16.14.14",
+			"resolved": "https://registry.npmjs.org/@types/react/-/react-16.14.14.tgz",
+			"integrity": "sha512-uwIWDYW8LznHzEMJl7ag9St1RsK0gw/xaFZ5+uI1ZM1HndwUgmPH3/wQkSb87GkOVg7shUxnpNW8DcN0AzvG5Q==",
 			"requires": {
 				"@types/prop-types": "*",
 				"@types/scheduler": "*",
@@ -29263,13 +29240,13 @@
 			}
 		},
 		"@typescript-eslint/eslint-plugin": {
-			"version": "4.29.1",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-4.29.1.tgz",
-			"integrity": "sha512-AHqIU+SqZZgBEiWOrtN94ldR3ZUABV5dUG94j8Nms9rQnHFc8fvDOue/58K4CFz6r8OtDDc35Pw9NQPWo0Ayrw==",
+			"version": "4.29.2",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-4.29.2.tgz",
+			"integrity": "sha512-x4EMgn4BTfVd9+Z+r+6rmWxoAzBaapt4QFqE+d8L8sUtYZYLDTK6VG/y/SMMWA5t1/BVU5Kf+20rX4PtWzUYZg==",
 			"dev": true,
 			"requires": {
-				"@typescript-eslint/experimental-utils": "4.29.1",
-				"@typescript-eslint/scope-manager": "4.29.1",
+				"@typescript-eslint/experimental-utils": "4.29.2",
+				"@typescript-eslint/scope-manager": "4.29.2",
 				"debug": "^4.3.1",
 				"functional-red-black-tree": "^1.0.1",
 				"regexpp": "^3.1.0",
@@ -29304,55 +29281,55 @@
 			}
 		},
 		"@typescript-eslint/experimental-utils": {
-			"version": "4.29.1",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/experimental-utils/-/experimental-utils-4.29.1.tgz",
-			"integrity": "sha512-kl6QG6qpzZthfd2bzPNSJB2YcZpNOrP6r9jueXupcZHnL74WiuSjaft7WSu17J9+ae9zTlk0KJMXPUj0daBxMw==",
+			"version": "4.29.2",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/experimental-utils/-/experimental-utils-4.29.2.tgz",
+			"integrity": "sha512-P6mn4pqObhftBBPAv4GQtEK7Yos1fz/MlpT7+YjH9fTxZcALbiiPKuSIfYP/j13CeOjfq8/fr9Thr2glM9ub7A==",
 			"dev": true,
 			"requires": {
 				"@types/json-schema": "^7.0.7",
-				"@typescript-eslint/scope-manager": "4.29.1",
-				"@typescript-eslint/types": "4.29.1",
-				"@typescript-eslint/typescript-estree": "4.29.1",
+				"@typescript-eslint/scope-manager": "4.29.2",
+				"@typescript-eslint/types": "4.29.2",
+				"@typescript-eslint/typescript-estree": "4.29.2",
 				"eslint-scope": "^5.1.1",
 				"eslint-utils": "^3.0.0"
 			}
 		},
 		"@typescript-eslint/parser": {
-			"version": "4.29.1",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-4.29.1.tgz",
-			"integrity": "sha512-3fL5iN20hzX3Q4OkG7QEPFjZV2qsVGiDhEwwh+EkmE/w7oteiOvUNzmpu5eSwGJX/anCryONltJ3WDmAzAoCMg==",
+			"version": "4.29.2",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-4.29.2.tgz",
+			"integrity": "sha512-WQ6BPf+lNuwteUuyk1jD/aHKqMQ9jrdCn7Gxt9vvBnzbpj7aWEf+aZsJ1zvTjx5zFxGCt000lsbD9tQPEL8u6g==",
 			"dev": true,
 			"requires": {
-				"@typescript-eslint/scope-manager": "4.29.1",
-				"@typescript-eslint/types": "4.29.1",
-				"@typescript-eslint/typescript-estree": "4.29.1",
+				"@typescript-eslint/scope-manager": "4.29.2",
+				"@typescript-eslint/types": "4.29.2",
+				"@typescript-eslint/typescript-estree": "4.29.2",
 				"debug": "^4.3.1"
 			}
 		},
 		"@typescript-eslint/scope-manager": {
-			"version": "4.29.1",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-4.29.1.tgz",
-			"integrity": "sha512-Hzv/uZOa9zrD/W5mftZa54Jd5Fed3tL6b4HeaOpwVSabJK8CJ+2MkDasnX/XK4rqP5ZTWngK1ZDeCi6EnxPQ7A==",
+			"version": "4.29.2",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-4.29.2.tgz",
+			"integrity": "sha512-mfHmvlQxmfkU8D55CkZO2sQOueTxLqGvzV+mG6S/6fIunDiD2ouwsAoiYCZYDDK73QCibYjIZmGhpvKwAB5BOA==",
 			"dev": true,
 			"requires": {
-				"@typescript-eslint/types": "4.29.1",
-				"@typescript-eslint/visitor-keys": "4.29.1"
+				"@typescript-eslint/types": "4.29.2",
+				"@typescript-eslint/visitor-keys": "4.29.2"
 			}
 		},
 		"@typescript-eslint/types": {
-			"version": "4.29.1",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-4.29.1.tgz",
-			"integrity": "sha512-Jj2yu78IRfw4nlaLtKjVaGaxh/6FhofmQ/j8v3NXmAiKafbIqtAPnKYrf0sbGjKdj0hS316J8WhnGnErbJ4RCA==",
+			"version": "4.29.2",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-4.29.2.tgz",
+			"integrity": "sha512-K6ApnEXId+WTGxqnda8z4LhNMa/pZmbTFkDxEBLQAbhLZL50DjeY0VIDCml/0Y3FlcbqXZrABqrcKxq+n0LwzQ==",
 			"dev": true
 		},
 		"@typescript-eslint/typescript-estree": {
-			"version": "4.29.1",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-4.29.1.tgz",
-			"integrity": "sha512-lIkkrR9E4lwZkzPiRDNq0xdC3f2iVCUjw/7WPJ4S2Sl6C3nRWkeE1YXCQ0+KsiaQRbpY16jNaokdWnm9aUIsfw==",
+			"version": "4.29.2",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-4.29.2.tgz",
+			"integrity": "sha512-TJ0/hEnYxapYn9SGn3dCnETO0r+MjaxtlWZ2xU+EvytF0g4CqTpZL48SqSNn2hXsPolnewF30pdzR9a5Lj3DNg==",
 			"dev": true,
 			"requires": {
-				"@typescript-eslint/types": "4.29.1",
-				"@typescript-eslint/visitor-keys": "4.29.1",
+				"@typescript-eslint/types": "4.29.2",
+				"@typescript-eslint/visitor-keys": "4.29.2",
 				"debug": "^4.3.1",
 				"globby": "^11.0.3",
 				"is-glob": "^4.0.1",
@@ -29387,25 +29364,25 @@
 			}
 		},
 		"@typescript-eslint/visitor-keys": {
-			"version": "4.29.1",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-4.29.1.tgz",
-			"integrity": "sha512-zLqtjMoXvgdZY/PG6gqA73V8BjqPs4af1v2kiiETBObp+uC6gRYnJLmJHxC0QyUrrHDLJPIWNYxoBV3wbcRlag==",
+			"version": "4.29.2",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-4.29.2.tgz",
+			"integrity": "sha512-bDgJLQ86oWHJoZ1ai4TZdgXzJxsea3Ee9u9wsTAvjChdj2WLcVsgWYAPeY7RQMn16tKrlQaBnpKv7KBfs4EQag==",
 			"dev": true,
 			"requires": {
-				"@typescript-eslint/types": "4.29.1",
+				"@typescript-eslint/types": "4.29.2",
 				"eslint-visitor-keys": "^2.0.0"
 			}
 		},
 		"@vue/compiler-core": {
-			"version": "3.2.1",
-			"resolved": "https://registry.npmjs.org/@vue/compiler-core/-/compiler-core-3.2.1.tgz",
-			"integrity": "sha512-UEJf2ZGww5wGVdrWIXIZo04KdJFGPmI2bHRUsBZ3AdyCAqJ5ykRXKOBn1OR1hvA2YzimudOEyHM+DpbBv91Kww==",
+			"version": "3.2.4",
+			"resolved": "https://registry.npmjs.org/@vue/compiler-core/-/compiler-core-3.2.4.tgz",
+			"integrity": "sha512-c8NuQq7mUXXxA4iqD5VUKpyVeklK53+DMbojYMyZ0VPPrb0BUWrZWFiqSDT+MFDv0f6Hv3QuLiHWb1BWMXBbrw==",
 			"dev": true,
 			"optional": true,
 			"requires": {
 				"@babel/parser": "^7.12.0",
 				"@babel/types": "^7.12.0",
-				"@vue/shared": "3.2.1",
+				"@vue/shared": "3.2.4",
 				"estree-walker": "^2.0.1",
 				"source-map": "^0.6.1"
 			},
@@ -29420,30 +29397,30 @@
 			}
 		},
 		"@vue/compiler-dom": {
-			"version": "3.2.1",
-			"resolved": "https://registry.npmjs.org/@vue/compiler-dom/-/compiler-dom-3.2.1.tgz",
-			"integrity": "sha512-tXg8tkPb3j54zNfWqoao9T1JI41yWPz8TROzmif/QNNA46eq8/SRuRsBd36i47GWaz7mh+yg3vOJ87/YBjcMyQ==",
+			"version": "3.2.4",
+			"resolved": "https://registry.npmjs.org/@vue/compiler-dom/-/compiler-dom-3.2.4.tgz",
+			"integrity": "sha512-uj1nwO4794fw2YsYas5QT+FU/YGrXbS0Qk+1c7Kp1kV7idhZIghWLTjyvYibpGoseFbYLPd+sW2/noJG5H04EQ==",
 			"dev": true,
 			"optional": true,
 			"requires": {
-				"@vue/compiler-core": "3.2.1",
-				"@vue/shared": "3.2.1"
+				"@vue/compiler-core": "3.2.4",
+				"@vue/shared": "3.2.4"
 			}
 		},
 		"@vue/compiler-sfc": {
-			"version": "3.2.1",
-			"resolved": "https://registry.npmjs.org/@vue/compiler-sfc/-/compiler-sfc-3.2.1.tgz",
-			"integrity": "sha512-fVLdme5RZVkBt+jxv2LCSRM72o4FX7BR2eu2FpjjEi1kEtUMKBDnjKwGWy7TyhTju0t0CocctyoM+G56vH7NpQ==",
+			"version": "3.2.4",
+			"resolved": "https://registry.npmjs.org/@vue/compiler-sfc/-/compiler-sfc-3.2.4.tgz",
+			"integrity": "sha512-GM+ouDdDzhqgkLmBH4bgq4kiZxJQArSppJiZHWHIx9XRaefHLmc1LBNPmN8ivm4SVfi2i7M2t9k8ZnjsScgzPQ==",
 			"dev": true,
 			"optional": true,
 			"requires": {
 				"@babel/parser": "^7.13.9",
 				"@babel/types": "^7.13.0",
 				"@types/estree": "^0.0.48",
-				"@vue/compiler-core": "3.2.1",
-				"@vue/compiler-dom": "3.2.1",
-				"@vue/compiler-ssr": "3.2.1",
-				"@vue/shared": "3.2.1",
+				"@vue/compiler-core": "3.2.4",
+				"@vue/compiler-dom": "3.2.4",
+				"@vue/compiler-ssr": "3.2.4",
+				"@vue/shared": "3.2.4",
 				"consolidate": "^0.16.0",
 				"estree-walker": "^2.0.1",
 				"hash-sum": "^2.0.0",
@@ -29483,20 +29460,20 @@
 			}
 		},
 		"@vue/compiler-ssr": {
-			"version": "3.2.1",
-			"resolved": "https://registry.npmjs.org/@vue/compiler-ssr/-/compiler-ssr-3.2.1.tgz",
-			"integrity": "sha512-6YAOtQunuEyYlVSjK1F7a7BXi7rxVfiTiJ0Ro7eq0q0MNCFV9Z+sN68lfa/E4ABVb0ledEY/Rt8kL23nwCoTCQ==",
+			"version": "3.2.4",
+			"resolved": "https://registry.npmjs.org/@vue/compiler-ssr/-/compiler-ssr-3.2.4.tgz",
+			"integrity": "sha512-bKZuXu9/4XwsFHFWIKQK+5kN7mxIIWmMmT2L4VVek7cvY/vm3p4WTsXYDGZJy0htOTXvM2ifr6sflg012T0hsw==",
 			"dev": true,
 			"optional": true,
 			"requires": {
-				"@vue/compiler-dom": "3.2.1",
-				"@vue/shared": "3.2.1"
+				"@vue/compiler-dom": "3.2.4",
+				"@vue/shared": "3.2.4"
 			}
 		},
 		"@vue/shared": {
-			"version": "3.2.1",
-			"resolved": "https://registry.npmjs.org/@vue/shared/-/shared-3.2.1.tgz",
-			"integrity": "sha512-INN92dVBNgd0TW9BqfQQKx/HWGCHhUUbAV5EZ5FgSCiEdwuZsJbGt1mdnaD9IxGhpiyOjP2ClxGG8SFp7ELcWg==",
+			"version": "3.2.4",
+			"resolved": "https://registry.npmjs.org/@vue/shared/-/shared-3.2.4.tgz",
+			"integrity": "sha512-j2j1MRmjalVKr3YBTxl/BClSIc8UQ8NnPpLYclxerK65JIowI4O7n8O8lElveEtEoHxy1d7BelPUDI0Q4bumqg==",
 			"dev": true,
 			"optional": true
 		},
@@ -29808,12 +29785,6 @@
 						"type-fest": "^0.8.1"
 					}
 				},
-				"prettier": {
-					"version": "npm:wp-prettier@2.2.1-beta-1",
-					"resolved": "https://registry.npmjs.org/wp-prettier/-/wp-prettier-2.2.1-beta-1.tgz",
-					"integrity": "sha512-+JHkqs9LC/JPp51yy1hzs3lQ7qeuWCwOcSzpQNeeY/G7oSpnF61vxt7hRh87zNRTr6ob2ndy0W8rVzhgrcA+Gw==",
-					"dev": true
-				},
 				"type-fest": {
 					"version": "0.8.1",
 					"resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.8.1.tgz",
@@ -29967,12 +29938,6 @@
 					"version": "4.0.0",
 					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
 					"integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
-					"dev": true
-				},
-				"prettier": {
-					"version": "npm:wp-prettier@2.2.1-beta-1",
-					"resolved": "https://registry.npmjs.org/wp-prettier/-/wp-prettier-2.2.1-beta-1.tgz",
-					"integrity": "sha512-+JHkqs9LC/JPp51yy1hzs3lQ7qeuWCwOcSzpQNeeY/G7oSpnF61vxt7hRh87zNRTr6ob2ndy0W8rVzhgrcA+Gw==",
 					"dev": true
 				},
 				"supports-color": {
@@ -30409,14 +30374,14 @@
 			"dev": true
 		},
 		"autoprefixer": {
-			"version": "10.3.1",
-			"resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-10.3.1.tgz",
-			"integrity": "sha512-L8AmtKzdiRyYg7BUXJTzigmhbQRCXFKz6SA1Lqo0+AR2FBbQ4aTAPFSDlOutnFkjhiz8my4agGXog1xlMjPJ6A==",
+			"version": "10.3.2",
+			"resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-10.3.2.tgz",
+			"integrity": "sha512-RHKq0YCvhxAn9987n0Gl6lkzLd39UKwCkUPMFE0cHhxU0SvcTjBxWG/CtkZ4/HvbqK9U5V8j03nAcGBlX3er/Q==",
 			"dev": true,
 			"requires": {
-				"browserslist": "^4.16.6",
-				"caniuse-lite": "^1.0.30001243",
-				"colorette": "^1.2.2",
+				"browserslist": "^4.16.8",
+				"caniuse-lite": "^1.0.30001251",
+				"colorette": "^1.3.0",
 				"fraction.js": "^4.1.1",
 				"normalize-range": "^0.1.2",
 				"postcss-value-parser": "^4.1.0"
@@ -30677,6 +30642,13 @@
 				"babel-plugin-jest-hoist": "^26.6.2",
 				"babel-preset-current-node-syntax": "^1.0.0"
 			}
+		},
+		"babelify": {
+			"version": "10.0.0",
+			"resolved": "https://registry.npmjs.org/babelify/-/babelify-10.0.0.tgz",
+			"integrity": "sha512-X40FaxyH7t3X+JFAKvb1H9wooWKLRCi8pg3m8poqtdZaIng+bjzp9RvKQCvRjF9isHiPkXspbbXT/zwXLtwgwg==",
+			"dev": true,
+			"requires": {}
 		},
 		"bail": {
 			"version": "1.0.5",
@@ -30958,16 +30930,16 @@
 			}
 		},
 		"browserslist": {
-			"version": "4.16.7",
-			"resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.16.7.tgz",
-			"integrity": "sha512-7I4qVwqZltJ7j37wObBe3SoTz+nS8APaNcrBOlgoirb6/HbEU2XxW/LpUDTCngM6iauwFqmRTuOMfyKnFGY5JA==",
+			"version": "4.16.8",
+			"resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.16.8.tgz",
+			"integrity": "sha512-sc2m9ohR/49sWEbPj14ZSSZqp+kbi16aLao42Hmn3Z8FpjuMaq2xCA2l4zl9ITfyzvnvyE0hcg62YkIGKxgaNQ==",
 			"dev": true,
 			"requires": {
-				"caniuse-lite": "^1.0.30001248",
-				"colorette": "^1.2.2",
-				"electron-to-chromium": "^1.3.793",
+				"caniuse-lite": "^1.0.30001251",
+				"colorette": "^1.3.0",
+				"electron-to-chromium": "^1.3.811",
 				"escalade": "^3.1.1",
-				"node-releases": "^1.1.73"
+				"node-releases": "^1.1.75"
 			}
 		},
 		"bser": {
@@ -31168,9 +31140,9 @@
 			}
 		},
 		"caniuse-lite": {
-			"version": "1.0.30001249",
-			"resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001249.tgz",
-			"integrity": "sha512-vcX4U8lwVXPdqzPWi6cAJ3FnQaqXbBqy/GZseKNQzRj37J7qZdGcBtxq/QLFNLLlfsoXLUdHw8Iwenri86Tagw==",
+			"version": "1.0.30001251",
+			"resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001251.tgz",
+			"integrity": "sha512-HOe1r+9VkU4TFmnU70z+r7OLmtR+/chB1rdcJUeQlAinjEeb0cKL20tlAtOagNZhbrtLnCvV19B4FmF1rgzl6A==",
 			"dev": true
 		},
 		"capture-exit": {
@@ -31934,13 +31906,13 @@
 					}
 				},
 				"normalize-package-data": {
-					"version": "3.0.2",
-					"resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-3.0.2.tgz",
-					"integrity": "sha512-6CdZocmfGaKnIHPVFhJJZ3GuR8SsLKvDANFp47Jmy51aKIr8akjAWTSxtpI+MBgBFdSMRyo4hMpDlT6dTffgZg==",
+					"version": "3.0.3",
+					"resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-3.0.3.tgz",
+					"integrity": "sha512-p2W1sgqij3zMMyRC067Dg16bfzVH+w7hyegmpIvZ4JNjqtGOVAIvLmjBx3yP7YTe9vKJgkoNOPjwQGogDoMXFA==",
 					"dev": true,
 					"requires": {
 						"hosted-git-info": "^4.0.1",
-						"resolve": "^1.20.0",
+						"is-core-module": "^2.5.0",
 						"semver": "^7.3.4",
 						"validate-npm-package-license": "^3.0.1"
 					}
@@ -32197,13 +32169,13 @@
 					}
 				},
 				"normalize-package-data": {
-					"version": "3.0.2",
-					"resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-3.0.2.tgz",
-					"integrity": "sha512-6CdZocmfGaKnIHPVFhJJZ3GuR8SsLKvDANFp47Jmy51aKIr8akjAWTSxtpI+MBgBFdSMRyo4hMpDlT6dTffgZg==",
+					"version": "3.0.3",
+					"resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-3.0.3.tgz",
+					"integrity": "sha512-p2W1sgqij3zMMyRC067Dg16bfzVH+w7hyegmpIvZ4JNjqtGOVAIvLmjBx3yP7YTe9vKJgkoNOPjwQGogDoMXFA==",
 					"dev": true,
 					"requires": {
 						"hosted-git-info": "^4.0.1",
-						"resolve": "^1.20.0",
+						"is-core-module": "^2.5.0",
 						"semver": "^7.3.4",
 						"validate-npm-package-license": "^3.0.1"
 					},
@@ -32385,13 +32357,13 @@
 					}
 				},
 				"normalize-package-data": {
-					"version": "3.0.2",
-					"resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-3.0.2.tgz",
-					"integrity": "sha512-6CdZocmfGaKnIHPVFhJJZ3GuR8SsLKvDANFp47Jmy51aKIr8akjAWTSxtpI+MBgBFdSMRyo4hMpDlT6dTffgZg==",
+					"version": "3.0.3",
+					"resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-3.0.3.tgz",
+					"integrity": "sha512-p2W1sgqij3zMMyRC067Dg16bfzVH+w7hyegmpIvZ4JNjqtGOVAIvLmjBx3yP7YTe9vKJgkoNOPjwQGogDoMXFA==",
 					"dev": true,
 					"requires": {
 						"hosted-git-info": "^4.0.1",
-						"resolve": "^1.20.0",
+						"is-core-module": "^2.5.0",
 						"semver": "^7.3.4",
 						"validate-npm-package-license": "^3.0.1"
 					}
@@ -32574,13 +32546,13 @@
 					}
 				},
 				"normalize-package-data": {
-					"version": "3.0.2",
-					"resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-3.0.2.tgz",
-					"integrity": "sha512-6CdZocmfGaKnIHPVFhJJZ3GuR8SsLKvDANFp47Jmy51aKIr8akjAWTSxtpI+MBgBFdSMRyo4hMpDlT6dTffgZg==",
+					"version": "3.0.3",
+					"resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-3.0.3.tgz",
+					"integrity": "sha512-p2W1sgqij3zMMyRC067Dg16bfzVH+w7hyegmpIvZ4JNjqtGOVAIvLmjBx3yP7YTe9vKJgkoNOPjwQGogDoMXFA==",
 					"dev": true,
 					"requires": {
 						"hosted-git-info": "^4.0.1",
-						"resolve": "^1.20.0",
+						"is-core-module": "^2.5.0",
 						"semver": "^7.3.4",
 						"validate-npm-package-license": "^3.0.1"
 					}
@@ -32718,15 +32690,15 @@
 			"dev": true
 		},
 		"core-js": {
-			"version": "3.16.1",
-			"resolved": "https://registry.npmjs.org/core-js/-/core-js-3.16.1.tgz",
-			"integrity": "sha512-AAkP8i35EbefU+JddyWi12AWE9f2N/qr/pwnDtWz4nyUIBGMJPX99ANFFRSw6FefM374lDujdtLDyhN2A/btHw==",
+			"version": "3.16.2",
+			"resolved": "https://registry.npmjs.org/core-js/-/core-js-3.16.2.tgz",
+			"integrity": "sha512-P0KPukO6OjMpjBtHSceAZEWlDD1M2Cpzpg6dBbrjFqFhBHe/BwhxaP820xKOjRn/lZRQirrCusIpLS/n2sgXLQ==",
 			"dev": true
 		},
 		"core-js-compat": {
-			"version": "3.16.1",
-			"resolved": "https://registry.npmjs.org/core-js-compat/-/core-js-compat-3.16.1.tgz",
-			"integrity": "sha512-NHXQXvRbd4nxp9TEmooTJLUf94ySUG6+DSsscBpTftN1lQLQ4LjnWvc7AoIo4UjDsFF3hB8Uh5LLCRRdaiT5MQ==",
+			"version": "3.16.2",
+			"resolved": "https://registry.npmjs.org/core-js-compat/-/core-js-compat-3.16.2.tgz",
+			"integrity": "sha512-4lUshXtBXsdmp8cDWh6KKiHUg40AjiuPD3bOWkNVsr1xkAhpUqCjaZ8lB1bKx9Gb5fXcbRbFJ4f4qpRIRTuJqQ==",
 			"dev": true,
 			"requires": {
 				"browserslist": "^4.16.7",
@@ -32742,9 +32714,9 @@
 			}
 		},
 		"core-js-pure": {
-			"version": "3.16.1",
-			"resolved": "https://registry.npmjs.org/core-js-pure/-/core-js-pure-3.16.1.tgz",
-			"integrity": "sha512-TyofCdMzx0KMhi84mVRS8rL1XsRk2SPUNz2azmth53iRN0/08Uim9fdhQTaZTG1LqaXHYVci4RDHka6WrXfnvg==",
+			"version": "3.16.2",
+			"resolved": "https://registry.npmjs.org/core-js-pure/-/core-js-pure-3.16.2.tgz",
+			"integrity": "sha512-oxKe64UH049mJqrKkynWp6Vu0Rlm/BTXO/bJZuN2mmR3RtOFNepLlSWDd1eo16PzHpQAoNG97rLU1V/YxesJjw==",
 			"dev": true
 		},
 		"core-util-is": {
@@ -32754,9 +32726,9 @@
 			"dev": true
 		},
 		"cosmiconfig": {
-			"version": "7.0.0",
-			"resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-7.0.0.tgz",
-			"integrity": "sha512-pondGvTuVYDk++upghXJabWzL6Kxu6f26ljFw64Swq9v6sQPUL3EUlVDV56diOjpCayKihL6hVe8exIACU4XcA==",
+			"version": "7.0.1",
+			"resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-7.0.1.tgz",
+			"integrity": "sha512-a1YWNUV2HwGimB7dU2s1wUMurNKjpx60HxBB6xUM8Re+2s1g1IIfJvFR0/iCF+XHdE0GMTKTuLR32UQff4TEyQ==",
 			"dev": true,
 			"requires": {
 				"@types/parse-json": "^4.0.0",
@@ -33466,13 +33438,6 @@
 					"integrity": "sha512-kFsOS0IbsuhO5ojF8Hc8z/8vEIOkylVBrjiZUbLTE3XFe0Qi+uu6HjzQixkFaqr0ZPAMZcBVxEwmsnsLPZ2Xsw==",
 					"dev": true
 				},
-				"babelify": {
-					"version": "10.0.0",
-					"resolved": "https://registry.npmjs.org/babelify/-/babelify-10.0.0.tgz",
-					"integrity": "sha512-X40FaxyH7t3X+JFAKvb1H9wooWKLRCi8pg3m8poqtdZaIng+bjzp9RvKQCvRjF9isHiPkXspbbXT/zwXLtwgwg==",
-					"dev": true,
-					"requires": {}
-				},
 				"find-up": {
 					"version": "3.0.0",
 					"resolved": "https://registry.npmjs.org/find-up/-/find-up-3.0.0.tgz",
@@ -33748,9 +33713,9 @@
 			}
 		},
 		"electron-to-chromium": {
-			"version": "1.3.802",
-			"resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.802.tgz",
-			"integrity": "sha512-dXB0SGSypfm3iEDxrb5n/IVKeX4uuTnFHdve7v+yKJqNpEP0D4mjFJ8e1znmSR+OOVlVC+kDO6f2kAkTFXvJBg==",
+			"version": "1.3.814",
+			"resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.814.tgz",
+			"integrity": "sha512-0mH03cyjh6OzMlmjauGg0TLd87ErIJqWiYxMcOLKf5w6p0YEOl7DJAj7BDlXEFmCguY5CQaKVOiMjAMODO2XDw==",
 			"dev": true
 		},
 		"elliptic": {
@@ -34174,9 +34139,9 @@
 					}
 				},
 				"globals": {
-					"version": "13.10.0",
-					"resolved": "https://registry.npmjs.org/globals/-/globals-13.10.0.tgz",
-					"integrity": "sha512-piHC3blgLGFjvOuMmWZX60f+na1lXFDhQXBf1UYp2fXPXqvEUbOhNwi6BsQ0bQishwedgnjkwv1d9zKf+MWw3g==",
+					"version": "13.11.0",
+					"resolved": "https://registry.npmjs.org/globals/-/globals-13.11.0.tgz",
+					"integrity": "sha512-08/xrJ7wQjK9kkkRoI3OFUBbLx4f+6x3SGwcPvQ0QH6goFDrOU2oyAWrmh3dJezu65buo+HBMzAMQy6rovVC3g==",
 					"dev": true,
 					"requires": {
 						"type-fest": "^0.20.2"
@@ -34267,9 +34232,9 @@
 			"requires": {}
 		},
 		"eslint-import-resolver-node": {
-			"version": "0.3.5",
-			"resolved": "https://registry.npmjs.org/eslint-import-resolver-node/-/eslint-import-resolver-node-0.3.5.tgz",
-			"integrity": "sha512-XMoPKjSpXbkeJ7ZZ9icLnJMTY5Mc1kZbCakHquaFsXPpyWOwK0TK6CODO+0ca54UoM9LKOxyUNnoVZRl8TeaAg==",
+			"version": "0.3.6",
+			"resolved": "https://registry.npmjs.org/eslint-import-resolver-node/-/eslint-import-resolver-node-0.3.6.tgz",
+			"integrity": "sha512-0En0w03NRVMn9Uiyn8YRPDKvWjxCWkslUEhGNTdGx15RvPJYQ+lbOlqrlNI2vEAs4pDYK4f/HN2TbDmk5TP0iw==",
 			"dev": true,
 			"requires": {
 				"debug": "^3.2.7",
@@ -34309,26 +34274,26 @@
 			}
 		},
 		"eslint-plugin-import": {
-			"version": "2.24.0",
-			"resolved": "https://registry.npmjs.org/eslint-plugin-import/-/eslint-plugin-import-2.24.0.tgz",
-			"integrity": "sha512-Kc6xqT9hiYi2cgybOc0I2vC9OgAYga5o/rAFinam/yF/t5uBqxQbauNPMC6fgb640T/89P0gFoO27FOilJ/Cqg==",
+			"version": "2.24.1",
+			"resolved": "https://registry.npmjs.org/eslint-plugin-import/-/eslint-plugin-import-2.24.1.tgz",
+			"integrity": "sha512-KSFWhNxPH8OGJwpRJJs+Z7I0a13E2iFQZJIvSnCu6KUs4qmgAm3xN9GYBCSoiGWmwA7gERZPXqYQjcoCROnYhQ==",
 			"dev": true,
 			"requires": {
 				"array-includes": "^3.1.3",
 				"array.prototype.flat": "^1.2.4",
 				"debug": "^2.6.9",
 				"doctrine": "^2.1.0",
-				"eslint-import-resolver-node": "^0.3.5",
+				"eslint-import-resolver-node": "^0.3.6",
 				"eslint-module-utils": "^2.6.2",
 				"find-up": "^2.0.0",
 				"has": "^1.0.3",
-				"is-core-module": "^2.4.0",
+				"is-core-module": "^2.6.0",
 				"minimatch": "^3.0.4",
-				"object.values": "^1.1.3",
+				"object.values": "^1.1.4",
 				"pkg-up": "^2.0.0",
 				"read-pkg-up": "^3.0.0",
 				"resolve": "^1.20.0",
-				"tsconfig-paths": "^3.9.0"
+				"tsconfig-paths": "^3.10.1"
 			},
 			"dependencies": {
 				"debug": {
@@ -34551,9 +34516,9 @@
 			}
 		},
 		"eslint-plugin-prettier": {
-			"version": "3.4.0",
-			"resolved": "https://registry.npmjs.org/eslint-plugin-prettier/-/eslint-plugin-prettier-3.4.0.tgz",
-			"integrity": "sha512-UDK6rJT6INSfcOo545jiaOwB701uAIt2/dR7WnFQoGCVl1/EMqdANBmwUaqqQ45aXprsTGzSa39LI1PyuRBxxw==",
+			"version": "3.4.1",
+			"resolved": "https://registry.npmjs.org/eslint-plugin-prettier/-/eslint-plugin-prettier-3.4.1.tgz",
+			"integrity": "sha512-htg25EUYUeIhKHXjOinK4BgCcDwtLHjqaxCDsMy5nbnUMkKFvIhMVCp+5GFUXQ4Nr8lBsPqtGAqBenbpFqAA2g==",
 			"dev": true,
 			"requires": {
 				"prettier-linter-helpers": "^1.0.0"
@@ -35083,9 +35048,9 @@
 			"dev": true
 		},
 		"fastq": {
-			"version": "1.11.1",
-			"resolved": "https://registry.npmjs.org/fastq/-/fastq-1.11.1.tgz",
-			"integrity": "sha512-HOnr8Mc60eNYl1gzwp6r5RoUyAn5/glBolUzP/Ez6IFVPMPirxn/9phgL6zhOtaTy7ISwPvQ+wT+hfcRZh/bzw==",
+			"version": "1.12.0",
+			"resolved": "https://registry.npmjs.org/fastq/-/fastq-1.12.0.tgz",
+			"integrity": "sha512-VNX0QkHK3RsXVKr9KrlUv/FoTa0NdbYoHHl7uXHv2rzyHSlxjdNAKug2twd9luJxpcyNeAgf5iPPMutJO67Dfg==",
 			"dev": true,
 			"requires": {
 				"reusify": "^1.0.4"
@@ -35851,13 +35816,13 @@
 					}
 				},
 				"normalize-package-data": {
-					"version": "3.0.2",
-					"resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-3.0.2.tgz",
-					"integrity": "sha512-6CdZocmfGaKnIHPVFhJJZ3GuR8SsLKvDANFp47Jmy51aKIr8akjAWTSxtpI+MBgBFdSMRyo4hMpDlT6dTffgZg==",
+					"version": "3.0.3",
+					"resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-3.0.3.tgz",
+					"integrity": "sha512-p2W1sgqij3zMMyRC067Dg16bfzVH+w7hyegmpIvZ4JNjqtGOVAIvLmjBx3yP7YTe9vKJgkoNOPjwQGogDoMXFA==",
 					"dev": true,
 					"requires": {
 						"hosted-git-info": "^4.0.1",
-						"resolve": "^1.20.0",
+						"is-core-module": "^2.5.0",
 						"semver": "^7.3.4",
 						"validate-npm-package-license": "^3.0.1"
 					}
@@ -36040,13 +36005,13 @@
 					}
 				},
 				"normalize-package-data": {
-					"version": "3.0.2",
-					"resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-3.0.2.tgz",
-					"integrity": "sha512-6CdZocmfGaKnIHPVFhJJZ3GuR8SsLKvDANFp47Jmy51aKIr8akjAWTSxtpI+MBgBFdSMRyo4hMpDlT6dTffgZg==",
+					"version": "3.0.3",
+					"resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-3.0.3.tgz",
+					"integrity": "sha512-p2W1sgqij3zMMyRC067Dg16bfzVH+w7hyegmpIvZ4JNjqtGOVAIvLmjBx3yP7YTe9vKJgkoNOPjwQGogDoMXFA==",
 					"dev": true,
 					"requires": {
 						"hosted-git-info": "^4.0.1",
-						"resolve": "^1.20.0",
+						"is-core-module": "^2.5.0",
 						"semver": "^7.3.4",
 						"validate-npm-package-license": "^3.0.1"
 					},
@@ -36913,10 +36878,13 @@
 			"dev": true
 		},
 		"is-bigint": {
-			"version": "1.0.3",
-			"resolved": "https://registry.npmjs.org/is-bigint/-/is-bigint-1.0.3.tgz",
-			"integrity": "sha512-ZU538ajmYJmzysE5yU4Y7uIrPQ2j704u+hXFiIPQExpqzzUbpe5jCPdTfmz7jXRxZdvjY3KZ3ZNenoXQovX+Dg==",
-			"dev": true
+			"version": "1.0.4",
+			"resolved": "https://registry.npmjs.org/is-bigint/-/is-bigint-1.0.4.tgz",
+			"integrity": "sha512-zB9CruMamjym81i2JZ3UMn54PKGsQzsJeo6xvN3HJJ4CAsQNB6iRutp2To77OfCNuoxspsIhzaPoO1zyCEhFOg==",
+			"dev": true,
+			"requires": {
+				"has-bigints": "^1.0.1"
+			}
 		},
 		"is-binary-path": {
 			"version": "1.0.1",
@@ -36960,9 +36928,9 @@
 			}
 		},
 		"is-core-module": {
-			"version": "2.5.0",
-			"resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.5.0.tgz",
-			"integrity": "sha512-TXCMSDsEHMEEZ6eCA8rwRDbLu55MRGmrctljsBX/2v1d9/GzqHOxW5c5oPSgrUt2vBFXebu9rGqckXGPWOlYpg==",
+			"version": "2.6.0",
+			"resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.6.0.tgz",
+			"integrity": "sha512-wShG8vs60jKfPWpF2KZRaAtvt3a20OAn7+IJ6hLPECpSABLcKtFKTTI4ZtH5QcBruBHlq+WsdHWyz0BCZW7svQ==",
 			"dev": true,
 			"requires": {
 				"has": "^1.0.3"
@@ -40699,9 +40667,9 @@
 			"optional": true
 		},
 		"nanoid": {
-			"version": "3.1.23",
-			"resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.1.23.tgz",
-			"integrity": "sha512-FiB0kzdP0FFVGDKlRLEQ1BgDzU87dy5NnzjeW9YZNt+/c3+q82EQDUwniSAUxp/F0gFNI1ZhKU1FqYsMuqZVnw==",
+			"version": "3.1.25",
+			"resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.1.25.tgz",
+			"integrity": "sha512-rdwtIXaXCLFAQbnfqDRnI6jaRHp9fTcYBjtFKE8eezcZ7LuLjhUaQGNeMXf1HmRoCH32CLz6XwX0TtxEOS/A3Q==",
 			"dev": true
 		},
 		"nanomatch": {
@@ -40911,9 +40879,9 @@
 			}
 		},
 		"node-releases": {
-			"version": "1.1.74",
-			"resolved": "https://registry.npmjs.org/node-releases/-/node-releases-1.1.74.tgz",
-			"integrity": "sha512-caJBVempXZPepZoZAPCWRTNxYQ+xtG/KAi4ozTA5A+nJ7IU+kLQCbqaUjb5Rwy14M9upBWiQ4NutcmW04LJSRw==",
+			"version": "1.1.75",
+			"resolved": "https://registry.npmjs.org/node-releases/-/node-releases-1.1.75.tgz",
+			"integrity": "sha512-Qe5OUajvqrqDSy6wrWFmMwfJ0jVgwiw4T3KqmbTcZ62qW0gQkheXYhcFM1+lOVcGUoRxcEcfyvFMAnDgaF1VWw==",
 			"dev": true
 		},
 		"normalize-package-data": {
@@ -40970,14 +40938,14 @@
 			}
 		},
 		"npm-package-json-lint": {
-			"version": "5.2.2",
-			"resolved": "https://registry.npmjs.org/npm-package-json-lint/-/npm-package-json-lint-5.2.2.tgz",
-			"integrity": "sha512-rs+mTLK31dRHzOrPcA33VoVgPxib0WecKGKOm6XkE186/FqiZGmGgkNLpxx1baUORkSmU1ETyi7aQXlZUzqZIA==",
+			"version": "5.2.3",
+			"resolved": "https://registry.npmjs.org/npm-package-json-lint/-/npm-package-json-lint-5.2.3.tgz",
+			"integrity": "sha512-rSgc4eVhtfwrU7AWwovqFWy8OEkgQL99vD3vWJmqtU9gxxJxKzi6Wqgo3gF7lhrBpyVcnlKxy/L2JCsvjWruDA==",
 			"dev": true,
 			"requires": {
 				"ajv": "^6.12.6",
 				"ajv-errors": "^1.0.1",
-				"chalk": "^4.1.1",
+				"chalk": "^4.1.2",
 				"cosmiconfig": "^6.0.0",
 				"debug": "^4.3.2",
 				"globby": "^11.0.4",
@@ -42227,11 +42195,10 @@
 			"dev": true
 		},
 		"prettier": {
-			"version": "2.3.2",
-			"resolved": "https://registry.npmjs.org/prettier/-/prettier-2.3.2.tgz",
-			"integrity": "sha512-lnJzDfJ66zkMy58OL5/NY5zp70S7Nz6KqcKkXYzn2tMVrNxvbqaBpg7H3qHaLxCJ5lNMsGuM8+ohS7cZrthdLQ==",
-			"dev": true,
-			"peer": true
+			"version": "npm:wp-prettier@2.2.1-beta-1",
+			"resolved": "https://registry.npmjs.org/wp-prettier/-/wp-prettier-2.2.1-beta-1.tgz",
+			"integrity": "sha512-+JHkqs9LC/JPp51yy1hzs3lQ7qeuWCwOcSzpQNeeY/G7oSpnF61vxt7hRh87zNRTr6ob2ndy0W8rVzhgrcA+Gw==",
+			"dev": true
 		},
 		"prettier-linter-helpers": {
 			"version": "1.0.0",
@@ -43353,9 +43320,9 @@
 			}
 		},
 		"sass": {
-			"version": "1.37.5",
-			"resolved": "https://registry.npmjs.org/sass/-/sass-1.37.5.tgz",
-			"integrity": "sha512-Cx3ewxz9QB/ErnVIiWg2cH0kiYZ0FPvheDTVC6BsiEGBTZKKZJ1Gq5Kq6jy3PKtL6+EJ8NIoaBW/RSd2R6cZOA==",
+			"version": "1.38.0",
+			"resolved": "https://registry.npmjs.org/sass/-/sass-1.38.0.tgz",
+			"integrity": "sha512-WBccZeMigAGKoI+NgD7Adh0ab1HUq+6BmyBUEaGxtErbUtWUevEbdgo5EZiJQofLUGcKtlNaO2IdN73AHEua5g==",
 			"dev": true,
 			"requires": {
 				"chokidar": ">=3.0.0 <4.0.0"
@@ -43570,12 +43537,12 @@
 			"dev": true
 		},
 		"sirv": {
-			"version": "1.0.12",
-			"resolved": "https://registry.npmjs.org/sirv/-/sirv-1.0.12.tgz",
-			"integrity": "sha512-+jQoCxndz7L2tqQL4ZyzfDhky0W/4ZJip3XoOuxyQWnAwMxindLl3Xv1qT4x1YX/re0leShvTm8Uk0kQspGhBg==",
+			"version": "1.0.14",
+			"resolved": "https://registry.npmjs.org/sirv/-/sirv-1.0.14.tgz",
+			"integrity": "sha512-czTFDFjK9lXj0u9mJ3OmJoXFztoilYS+NdRPcJoT182w44wSEkHSiO7A2517GLJ8wKM4GjCm2OXE66Dhngbzjg==",
 			"dev": true,
 			"requires": {
-				"@polka/url": "^1.0.0-next.15",
+				"@polka/url": "^1.0.0-next.17",
 				"mime": "^2.3.1",
 				"totalist": "^1.0.0"
 			}
@@ -44699,13 +44666,13 @@
 					}
 				},
 				"normalize-package-data": {
-					"version": "3.0.2",
-					"resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-3.0.2.tgz",
-					"integrity": "sha512-6CdZocmfGaKnIHPVFhJJZ3GuR8SsLKvDANFp47Jmy51aKIr8akjAWTSxtpI+MBgBFdSMRyo4hMpDlT6dTffgZg==",
+					"version": "3.0.3",
+					"resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-3.0.3.tgz",
+					"integrity": "sha512-p2W1sgqij3zMMyRC067Dg16bfzVH+w7hyegmpIvZ4JNjqtGOVAIvLmjBx3yP7YTe9vKJgkoNOPjwQGogDoMXFA==",
 					"dev": true,
 					"requires": {
 						"hosted-git-info": "^4.0.1",
-						"resolve": "^1.20.0",
+						"is-core-module": "^2.5.0",
 						"semver": "^7.3.4",
 						"validate-npm-package-license": "^3.0.1"
 					}
@@ -45200,9 +45167,9 @@
 			"dev": true
 		},
 		"tar": {
-			"version": "6.1.7",
-			"resolved": "https://registry.npmjs.org/tar/-/tar-6.1.7.tgz",
-			"integrity": "sha512-PBoRkOJU0X3lejJ8GaRCsobjXTgFofRDSPdSUhRSdlwJfifRlQBwGXitDItdGFu0/h0XDMCkig0RN1iT7DBxhA==",
+			"version": "6.1.10",
+			"resolved": "https://registry.npmjs.org/tar/-/tar-6.1.10.tgz",
+			"integrity": "sha512-kvvfiVvjGMxeUNB6MyYv5z7vhfFRwbwCXJAeL0/lnbrttBVqcMOnpHUf0X42LrPMR8mMpgapkJMchFH4FSHzNA==",
 			"dev": true,
 			"requires": {
 				"chownr": "^2.0.0",
@@ -45633,9 +45600,9 @@
 			}
 		},
 		"tslib": {
-			"version": "2.3.0",
-			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.0.tgz",
-			"integrity": "sha512-N82ooyxVNm6h1riLCoyS9e3fuJ3AMG2zIZs2Gd1ATcSFjSA23Q0fzjjZeh0jbJvWVDZ0cJT8yaNNaaXHzueNjg==",
+			"version": "2.3.1",
+			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
+			"integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw==",
 			"dev": true
 		},
 		"tsutils": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
-	"name": "@sixach/wp-react-hooks",
+	"name": "@sixa/wp-react-hooks",
 	"version": "1.1.1",
 	"lockfileVersion": 2,
 	"requires": true,
 	"packages": {
 		"": {
-			"name": "@sixach/wp-react-hooks",
+			"name": "@sixa/wp-react-hooks",
 			"version": "1.1.1",
 			"license": "GPL-3.0-or-later",
 			"dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-	"name": "@sixach/wp-react-hooks",
+	"name": "@sixa/wp-react-hooks",
 	"version": "1.1.1",
 	"description": "A collection of most used React hooks crafted for the sixa projects.",
 	"keywords": [
@@ -56,5 +56,8 @@
 		"husky": "^7.0.1",
 		"lint-staged": "11.1.2",
 		"lodash": "4.17.21"
+	},
+	"publishConfig": {
+		"access": "public"
 	}
 }

--- a/package.json
+++ b/package.json
@@ -32,17 +32,13 @@
 		"lint:pkg-json": "wp-scripts lint-pkg-json",
 		"packages-update": "wp-scripts packages-update",
 		"prepublishOnly": "npm run format && npm run build",
-		"docs": "documentation build src/** -f html --github -o docs"
-	},
-	"husky": {
-		"hooks": {
-			"pre-commit": "lint-staged"
-		}
+		"docs": "documentation build src/** -f html --github -o docs",
+		"prepare": "husky install"
 	},
 	"lint-staged": {
 		"*.{js,ts,tsx}": [
 			"npm run lint:js",
-			"npm run format:js"
+			"npm run format"
 		]
 	},
 	"dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@sixach/wp-react-hooks",
-	"version": "1.1.0",
+	"version": "1.1.1",
 	"description": "A collection of most used React hooks crafted for the sixa projects.",
 	"keywords": [
 		"gutenberg",
@@ -56,8 +56,5 @@
 		"husky": "^7.0.1",
 		"lint-staged": "11.1.2",
 		"lodash": "4.17.21"
-	},
-	"publishConfig": {
-		"registry": "https://npm.pkg.github.com/"
 	}
 }


### PR DESCRIPTION
Maintenance update and preparation for publication on the NPM registry.
- fixed husky 7 setup
- updated `.npmignore` to ignore everything that's not relevant for the public package
- bumped version to `1.1.1`
- renamed package scope from `sixach` to `sixa` (because that's the organisation name on NPM)
- rebuilt `package-lock.json` due to an issue with `prettier`