### PR TITLE
WooCommerce Hooks ⚓ 

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -2,7 +2,7 @@
 <html lang="en">
 <head>
   <meta charset='utf-8'>
-  <title>@sixa/wp-react-hooks 1.3.0 | Documentation</title>
+  <title>@sixa/wp-react-hooks 1.4.0 | Documentation</title>
   <meta name='description' content='A collection of most used React hooks crafted for the sixa projects.'>
   <meta name='viewport' content='width=device-width,initial-scale=1'>
   <link href='assets/bass.css' rel='stylesheet'>
@@ -15,7 +15,7 @@
       <div id='split-left' class='overflow-auto fs0 height-viewport-100'>
         <div class='py1 px2'>
           <h3 class='mb0 no-anchor'>@sixa/wp-react-hooks</h3>
-          <div class='mb1'><code>1.3.0</code></div>
+          <div class='mb1'><code>1.4.0</code></div>
           <input
             placeholder='Filter'
             id='filter-input'
@@ -99,9 +99,39 @@
               
                 
                 <li><a
+                  href='#usetoggle'
+                  class="">
+                  useToggle
+                  
+                </a>
+                
+                </li>
+              
+                
+                <li><a
                   href='#usegetposts'
                   class="">
                   useGetPosts
+                  
+                </a>
+                
+                </li>
+              
+                
+                <li><a
+                  href='#usegetproducts'
+                  class="">
+                  useGetProducts
+                  
+                </a>
+                
+                </li>
+              
+                
+                <li><a
+                  href='#usegetproductterms'
+                  class="">
+                  useGetProductTerms
                   
                 </a>
                 
@@ -157,16 +187,6 @@
                 
                 </li>
               
-                
-                <li><a
-                  href='#usetoggle'
-                  class="">
-                  useToggle
-                  
-                </a>
-                
-                </li>
-              
             </ul>
           </div>
           <div class='mt1 h6 quiet'>
@@ -187,7 +207,7 @@
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/sixach/wp-react-hooks/blob/fd39d81d2c766f32f94b8a3b2ca78a6bd1ed123c/src/useActiveTab/index.js#L28-L31'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/sixach/wp-react-hooks/blob/3a92df847d871d6e59fb11a076cf8ae7dbea9d94/src/useActiveTab/index.js#L28-L31'>
       <span>src/useActiveTab/index.js</span>
       </a>
     
@@ -278,7 +298,7 @@
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/sixach/wp-react-hooks/blob/fd39d81d2c766f32f94b8a3b2ca78a6bd1ed123c/src/useConditionalRef/index.js#L31-L31'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/sixach/wp-react-hooks/blob/3a92df847d871d6e59fb11a076cf8ae7dbea9d94/src/useConditionalRef/index.js#L31-L31'>
       <span>src/useConditionalRef/index.js</span>
       </a>
     
@@ -335,7 +355,7 @@ a React component, making any hook invalid by throwing a fatal compilation error
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/sixach/wp-react-hooks/blob/fd39d81d2c766f32f94b8a3b2ca78a6bd1ed123c/src/useConditionalRef/index.js#L21-L32'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/sixach/wp-react-hooks/blob/3a92df847d871d6e59fb11a076cf8ae7dbea9d94/src/useConditionalRef/index.js#L21-L32'>
       <span>src/useConditionalRef/index.js</span>
       </a>
     
@@ -429,7 +449,7 @@ a React component, making any hook invalid by throwing a fatal compilation error
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/sixach/wp-react-hooks/blob/fd39d81d2c766f32f94b8a3b2ca78a6bd1ed123c/src/useDidMount/index.js#L29-L35'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/sixach/wp-react-hooks/blob/3a92df847d871d6e59fb11a076cf8ae7dbea9d94/src/useDidMount/index.js#L29-L35'>
       <span>src/useDidMount/index.js</span>
       </a>
     
@@ -512,7 +532,7 @@ a React component, making any hook invalid by throwing a fatal compilation error
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/sixach/wp-react-hooks/blob/fd39d81d2c766f32f94b8a3b2ca78a6bd1ed123c/src/useDidUpdate/index.js#L25-L35'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/sixach/wp-react-hooks/blob/3a92df847d871d6e59fb11a076cf8ae7dbea9d94/src/useDidUpdate/index.js#L25-L35'>
       <span>src/useDidUpdate/index.js</span>
       </a>
     
@@ -606,7 +626,7 @@ conditions to fire callback when one of the conditions changes.</p>
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/sixach/wp-react-hooks/blob/fd39d81d2c766f32f94b8a3b2ca78a6bd1ed123c/src/useToast/index.js#L21-L26'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/sixach/wp-react-hooks/blob/3a92df847d871d6e59fb11a076cf8ae7dbea9d94/src/useToast/index.js#L21-L26'>
       <span>src/useToast/index.js</span>
       </a>
     
@@ -675,7 +695,7 @@ toast( <span class="hljs-string">&#x27;Text to display as a toast message!&#x27;
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/sixach/wp-react-hooks/blob/fd39d81d2c766f32f94b8a3b2ca78a6bd1ed123c/src/useGetNodeList/index.js#L49-L66'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/sixach/wp-react-hooks/blob/3a92df847d871d6e59fb11a076cf8ae7dbea9d94/src/useGetNodeList/index.js#L49-L66'>
       <span>src/useGetNodeList/index.js</span>
       </a>
     
@@ -752,12 +772,105 @@ toast( <span class="hljs-string">&#x27;Text to display as a toast message!&#x27;
   
   <div class='clearfix'>
     
+    <h3 class='fl m0' id='usetoggle'>
+      useToggle
+    </h3>
+    
+    
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/sixach/wp-react-hooks/blob/3a92df847d871d6e59fb11a076cf8ae7dbea9d94/src/useToggle/index.js#L30-L32'>
+      <span>src/useToggle/index.js</span>
+      </a>
+    
+  </div>
+  
+
+  <p>This hook takes a parameter with value and allows for quickly toggling the value.</p>
+
+    <div class='pre p1 fill-light mt0'>useToggle(initialValue: (any | <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Boolean">boolean</a>), toggleFunction: <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Statements/function">Function</a>): <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array">Array</a></div>
+  
+  
+
+  
+  
+  
+  
+  
+  <div>Since: 1.1.0</div>
+
+  
+    <div class='py1 quiet mt1 prose-big'>Parameters</div>
+    <div class='prose'>
+      
+        <div class='space-bottom0'>
+          <div>
+            <span class='code bold'>initialValue</span> <code class='quiet'>((any | <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Boolean">boolean</a>))</code>
+	    Initial value of the toggle.
+
+          </div>
+          
+        </div>
+      
+        <div class='space-bottom0'>
+          <div>
+            <span class='code bold'>toggleFunction</span> <code class='quiet'>(<a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Statements/function">Function</a>)</code>
+	    A toggle function. This allows for non boolean toggles.
+
+          </div>
+          
+        </div>
+      
+    </div>
+  
+
+  
+
+  
+    
+      <div class='py1 quiet mt1 prose-big'>Returns</div>
+      <code><a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array">Array</a></code>:
+        Returns a stateful value, and a function to update it.
+
+      
+    
+  
+
+  
+
+  
+
+  
+    <div class='py1 quiet mt1 prose-big'>Example</div>
+    
+      
+      <pre class='p1 overflow-auto round fill-light'><span class="hljs-keyword">const</span> [ value1, toggleValue1 ] = useToggle();
+<span class="hljs-keyword">const</span> [ value2, toggleValue2 ] = useToggle( <span class="hljs-literal">true</span> );
+<span class="hljs-keyword">const</span> [ value3, toggleValue3 ] = useToggle( <span class="hljs-string">&#x27;start&#x27;</span>, customToggleFunction );</pre>
+    
+  
+
+  
+
+  
+
+  
+
+  
+</section>
+
+          
+        
+          
+          <section class='p2 mb2 clearfix bg-white minishadow'>
+
+  
+  <div class='clearfix'>
+    
     <h3 class='fl m0' id='usegetposts'>
       useGetPosts
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/sixach/wp-react-hooks/blob/fd39d81d2c766f32f94b8a3b2ca78a6bd1ed123c/src/useGetPosts/index.js#L60-L79'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/sixach/wp-react-hooks/blob/3a92df847d871d6e59fb11a076cf8ae7dbea9d94/src/useGetPosts/index.js#L67-L90'>
       <span>src/useGetPosts/index.js</span>
       </a>
     
@@ -776,7 +889,7 @@ this list when any of the direct arguments changed.</p>
   
   
   
-  <div>Since: 1.2.0</div>
+  <div>Since: 1.4.0</div>
 
   
     <div class='py1 quiet mt1 prose-big'>Parameters</div>
@@ -854,12 +967,198 @@ this list when any of the direct arguments changed.</p>
   
   <div class='clearfix'>
     
+    <h3 class='fl m0' id='usegetproducts'>
+      useGetProducts
+    </h3>
+    
+    
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/sixach/wp-react-hooks/blob/3a92df847d871d6e59fb11a076cf8ae7dbea9d94/src/useGetProducts/index.js#L66-L89'>
+      <span>src/useGetProducts/index.js</span>
+      </a>
+    
+  </div>
+  
+
+  <p>Retrieve list of product posts and maintain refreshing
+this list when any of the direct arguments changed.</p>
+
+    <div class='pre p1 fill-light mt0'>useGetProducts(args: <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object">Object</a>, clientId: <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String">string</a>): <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object">Object</a></div>
+  
+  
+
+  
+  
+  
+  
+  
+  <div>Since: 1.4.0</div>
+
+  
+    <div class='py1 quiet mt1 prose-big'>Parameters</div>
+    <div class='prose'>
+      
+        <div class='space-bottom0'>
+          <div>
+            <span class='code bold'>args</span> <code class='quiet'>(<a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object">Object</a>
+            = <code>{}</code>)</code>
+	    Arguments to be passed to the apiFetch method.
+
+          </div>
+          
+        </div>
+      
+        <div class='space-bottom0'>
+          <div>
+            <span class='code bold'>clientId</span> <code class='quiet'>(<a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String">string</a>)</code>
+	    The block’s client id.
+
+          </div>
+          
+        </div>
+      
+    </div>
+  
+
+  
+
+  
+    
+      <div class='py1 quiet mt1 prose-big'>Returns</div>
+      <code><a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object">Object</a></code>:
+        List of posts retrieved from the API along with a list of options to select from.
+
+      
+    
+  
+
+  
+
+  
+
+  
+    <div class='py1 quiet mt1 prose-big'>Example</div>
+    
+      
+      <pre class='p1 overflow-auto round fill-light'><span class="hljs-keyword">const</span> { productsOptions, productsQuery } = useGetProducts( { <span class="hljs-attr">order</span>: <span class="hljs-string">&#x27;asc&#x27;</span> }, clientId );</pre>
+    
+  
+
+  
+
+  
+
+  
+
+  
+</section>
+
+          
+        
+          
+          <section class='p2 mb2 clearfix bg-white minishadow'>
+
+  
+  <div class='clearfix'>
+    
+    <h3 class='fl m0' id='usegetproductterms'>
+      useGetProductTerms
+    </h3>
+    
+    
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/sixach/wp-react-hooks/blob/3a92df847d871d6e59fb11a076cf8ae7dbea9d94/src/useGetProductTerms/index.js#L65-L88'>
+      <span>src/useGetProductTerms/index.js</span>
+      </a>
+    
+  </div>
+  
+
+  <p>Retrieve list of product taxonomy terms only invoked
+immediately after the Edit component is mounted.</p>
+
+    <div class='pre p1 fill-light mt0'>useGetProductTerms(taxonomy: <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String">string</a>, args: <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object">Object</a>): <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object">Object</a></div>
+  
+  
+
+  
+  
+  
+  
+  
+  <div>Since: 1.4.0</div>
+
+  
+    <div class='py1 quiet mt1 prose-big'>Parameters</div>
+    <div class='prose'>
+      
+        <div class='space-bottom0'>
+          <div>
+            <span class='code bold'>taxonomy</span> <code class='quiet'>(<a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String">string</a>)</code>
+	    Taxonomy name.
+
+          </div>
+          
+        </div>
+      
+        <div class='space-bottom0'>
+          <div>
+            <span class='code bold'>args</span> <code class='quiet'>(<a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object">Object</a>
+            = <code>{}</code>)</code>
+	    Arguments to be passed to the apiFetch method.
+
+          </div>
+          
+        </div>
+      
+    </div>
+  
+
+  
+
+  
+    
+      <div class='py1 quiet mt1 prose-big'>Returns</div>
+      <code><a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object">Object</a></code>:
+        List of terms retrieved from the API along with a list of options to select from.
+
+      
+    
+  
+
+  
+
+  
+
+  
+    <div class='py1 quiet mt1 prose-big'>Example</div>
+    
+      
+      <pre class='p1 overflow-auto round fill-light'><span class="hljs-keyword">const</span> { termsOptions, termsQuery } = useGetTerms( <span class="hljs-string">&#x27;categories&#x27;</span> );</pre>
+    
+  
+
+  
+
+  
+
+  
+
+  
+</section>
+
+          
+        
+          
+          <section class='p2 mb2 clearfix bg-white minishadow'>
+
+  
+  <div class='clearfix'>
+    
     <h3 class='fl m0' id='usegetterms'>
       useGetTerms
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/sixach/wp-react-hooks/blob/fd39d81d2c766f32f94b8a3b2ca78a6bd1ed123c/src/useGetTerms/index.js#L58-L77'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/sixach/wp-react-hooks/blob/3a92df847d871d6e59fb11a076cf8ae7dbea9d94/src/useGetTerms/index.js#L65-L88'>
       <span>src/useGetTerms/index.js</span>
       </a>
     
@@ -878,7 +1177,7 @@ immediately after the Edit component is mounted.</p>
   
   
   
-  <div>Since: 1.2.0</div>
+  <div>Since: 1.4.0</div>
 
   
     <div class='py1 quiet mt1 prose-big'>Parameters</div>
@@ -952,7 +1251,7 @@ immediately after the Edit component is mounted.</p>
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/sixach/wp-react-hooks/blob/fd39d81d2c766f32f94b8a3b2ca78a6bd1ed123c/src/useInputValue/index.js#L22-L29'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/sixach/wp-react-hooks/blob/3a92df847d871d6e59fb11a076cf8ae7dbea9d94/src/useInputValue/index.js#L22-L29'>
       <span>src/useInputValue/index.js</span>
       </a>
     
@@ -1036,7 +1335,7 @@ and updates it when the <code>onChange</code> event raises.</p>
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/sixach/wp-react-hooks/blob/fd39d81d2c766f32f94b8a3b2ca78a6bd1ed123c/src/useLatLngBounds/index.js#L44-L69'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/sixach/wp-react-hooks/blob/3a92df847d871d6e59fb11a076cf8ae7dbea9d94/src/useLatLngBounds/index.js#L44-L69'>
       <span>src/useLatLngBounds/index.js</span>
       </a>
     
@@ -1139,7 +1438,7 @@ and updates it when the <code>onChange</code> event raises.</p>
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/sixach/wp-react-hooks/blob/fd39d81d2c766f32f94b8a3b2ca78a6bd1ed123c/src/usePreparePosts/index.js#L37-L48'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/sixach/wp-react-hooks/blob/3a92df847d871d6e59fb11a076cf8ae7dbea9d94/src/usePreparePosts/index.js#L37-L48'>
       <span>src/usePreparePosts/index.js</span>
       </a>
     
@@ -1244,7 +1543,7 @@ and slices the query according to the maximum limit determined.</p>
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/sixach/wp-react-hooks/blob/fd39d81d2c766f32f94b8a3b2ca78a6bd1ed123c/src/useTimeout/index.js#L23-L55'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/sixach/wp-react-hooks/blob/3a92df847d871d6e59fb11a076cf8ae7dbea9d94/src/useTimeout/index.js#L23-L55'>
       <span>src/useTimeout/index.js</span>
       </a>
     
@@ -1312,99 +1611,6 @@ and slices the query according to the maximum limit determined.</p>
       <pre class='p1 overflow-auto round fill-light'><span class="hljs-keyword">const</span> [ isBusy, toggleIsBusy ] = useToggle( <span class="hljs-literal">true</span> );
 <span class="hljs-keyword">const</span> { start } = useTimeout( toggleIsBusy, <span class="hljs-number">2000</span> );
 start();</pre>
-    
-  
-
-  
-
-  
-
-  
-
-  
-</section>
-
-          
-        
-          
-          <section class='p2 mb2 clearfix bg-white minishadow'>
-
-  
-  <div class='clearfix'>
-    
-    <h3 class='fl m0' id='usetoggle'>
-      useToggle
-    </h3>
-    
-    
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/sixach/wp-react-hooks/blob/fd39d81d2c766f32f94b8a3b2ca78a6bd1ed123c/src/useToggle/index.js#L30-L32'>
-      <span>src/useToggle/index.js</span>
-      </a>
-    
-  </div>
-  
-
-  <p>This hook takes a parameter with value and allows for quickly toggling the value.</p>
-
-    <div class='pre p1 fill-light mt0'>useToggle(initialValue: (any | <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Boolean">boolean</a>), toggleFunction: <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Statements/function">Function</a>): <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array">Array</a></div>
-  
-  
-
-  
-  
-  
-  
-  
-  <div>Since: 1.1.0</div>
-
-  
-    <div class='py1 quiet mt1 prose-big'>Parameters</div>
-    <div class='prose'>
-      
-        <div class='space-bottom0'>
-          <div>
-            <span class='code bold'>initialValue</span> <code class='quiet'>((any | <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Boolean">boolean</a>))</code>
-	    Initial value of the toggle.
-
-          </div>
-          
-        </div>
-      
-        <div class='space-bottom0'>
-          <div>
-            <span class='code bold'>toggleFunction</span> <code class='quiet'>(<a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Statements/function">Function</a>)</code>
-	    A toggle function. This allows for non boolean toggles.
-
-          </div>
-          
-        </div>
-      
-    </div>
-  
-
-  
-
-  
-    
-      <div class='py1 quiet mt1 prose-big'>Returns</div>
-      <code><a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array">Array</a></code>:
-        Returns a stateful value, and a function to update it.
-
-      
-    
-  
-
-  
-
-  
-
-  
-    <div class='py1 quiet mt1 prose-big'>Example</div>
-    
-      
-      <pre class='p1 overflow-auto round fill-light'><span class="hljs-keyword">const</span> [ value1, toggleValue1 ] = useToggle();
-<span class="hljs-keyword">const</span> [ value2, toggleValue2 ] = useToggle( <span class="hljs-literal">true</span> );
-<span class="hljs-keyword">const</span> [ value3, toggleValue3 ] = useToggle( <span class="hljs-string">&#x27;start&#x27;</span>, customToggleFunction );</pre>
     
   
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "@sixa/wp-react-hooks",
-	"version": "1.2.2",
+	"version": "1.4.0",
 	"lockfileVersion": 2,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "@sixa/wp-react-hooks",
-			"version": "1.2.2",
+			"version": "1.4.0",
 			"license": "GPL-3.0-or-later",
 			"dependencies": {
 				"@wordpress/api-fetch": "^5.2.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,10 +15,10 @@
 				"@wordpress/i18n": "^4.2.2",
 				"@wordpress/url": "^3.2.2",
 				"react-geocode": "^0.2.3",
-				"use-deep-compare-effect": "^1.6.1"
+				"use-deep-compare-effect": "^1.8.0"
 			},
 			"devDependencies": {
-				"@babel/cli": "^7.15.4",
+				"@babel/cli": "^7.15.7",
 				"@babel/core": "^7.15.5",
 				"@babel/preset-env": "^7.15.6",
 				"@babel/preset-react": "7.14.5",
@@ -33,9 +33,9 @@
 			}
 		},
 		"node_modules/@babel/cli": {
-			"version": "7.15.4",
-			"resolved": "https://registry.npmjs.org/@babel/cli/-/cli-7.15.4.tgz",
-			"integrity": "sha512-9RhhQ7tgKRcSO/jI3rNLxalLSk30cHqeM8bb+nGOJTyYBDpkoXw/A9QHZ2SYjlslAt4tr90pZQGIEobwWHSIDw==",
+			"version": "7.15.7",
+			"resolved": "https://registry.npmjs.org/@babel/cli/-/cli-7.15.7.tgz",
+			"integrity": "sha512-YW5wOprO2LzMjoWZ5ZG6jfbY9JnkDxuHDwvnrThnuYtByorova/I0HNXJedrUfwuXFQfYOjcqDA4PU3qlZGZjg==",
 			"dev": true,
 			"dependencies": {
 				"commander": "^4.0.1",
@@ -54,7 +54,7 @@
 				"node": ">=6.9.0"
 			},
 			"optionalDependencies": {
-				"@nicolo-ribaudo/chokidar-2": "2.1.8-no-fsevents.2",
+				"@nicolo-ribaudo/chokidar-2": "2.1.8-no-fsevents.3",
 				"chokidar": "^3.4.0"
 			},
 			"peerDependencies": {
@@ -3062,24 +3062,11 @@
 			}
 		},
 		"node_modules/@nicolo-ribaudo/chokidar-2": {
-			"version": "2.1.8-no-fsevents.2",
-			"resolved": "https://registry.npmjs.org/@nicolo-ribaudo/chokidar-2/-/chokidar-2-2.1.8-no-fsevents.2.tgz",
-			"integrity": "sha512-Fb8WxUFOBQVl+CX4MWet5o7eCc6Pj04rXIwVKZ6h1NnqTo45eOQW6aWyhG25NIODvWFwTDMwBsYxrQ3imxpetg==",
+			"version": "2.1.8-no-fsevents.3",
+			"resolved": "https://registry.npmjs.org/@nicolo-ribaudo/chokidar-2/-/chokidar-2-2.1.8-no-fsevents.3.tgz",
+			"integrity": "sha512-s88O1aVtXftvp5bCPB7WnmXc5IwOZZ7YPuwNPt+GtOOXpPvad1LfbmjYv+qII7zP6RU2QGnqve27dnLycEnyEQ==",
 			"dev": true,
-			"optional": true,
-			"dependencies": {
-				"anymatch": "^2.0.0",
-				"async-each": "^1.0.1",
-				"braces": "^2.3.2",
-				"glob-parent": "^5.1.2",
-				"inherits": "^2.0.3",
-				"is-binary-path": "^1.0.0",
-				"is-glob": "^4.0.0",
-				"normalize-path": "^3.0.0",
-				"path-is-absolute": "^1.0.0",
-				"readdirp": "^2.2.1",
-				"upath": "^1.1.1"
-			}
+			"optional": true
 		},
 		"node_modules/@nodelib/fs.scandir": {
 			"version": "2.1.5",
@@ -6302,13 +6289,6 @@
 				"lodash": "^4.17.14"
 			}
 		},
-		"node_modules/async-each": {
-			"version": "1.0.3",
-			"resolved": "https://registry.npmjs.org/async-each/-/async-each-1.0.3.tgz",
-			"integrity": "sha512-z/WhQ5FPySLdvREByI2vZiTWwCnF0moMJ1hK9YQwDTHKh6I7/uSckMetoRGb5UBZPC1z0jlw+n/XCgjeH7y1AQ==",
-			"dev": true,
-			"optional": true
-		},
 		"node_modules/async-limiter": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/async-limiter/-/async-limiter-1.0.1.tgz",
@@ -6837,16 +6817,6 @@
 			"dev": true,
 			"engines": {
 				"node": "*"
-			}
-		},
-		"node_modules/binary-extensions": {
-			"version": "1.13.1",
-			"resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-1.13.1.tgz",
-			"integrity": "sha512-Un7MIEDdUC5gNpcGDV97op1Ywk748MpHcFTHoYs6qnj1Z3j7I53VG3nwZhKzoBZmbdRNnb6WRdFlwl7tSDuZGw==",
-			"dev": true,
-			"optional": true,
-			"engines": {
-				"node": ">=0.10.0"
 			}
 		},
 		"node_modules/bl": {
@@ -14599,19 +14569,6 @@
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/ljharb"
-			}
-		},
-		"node_modules/is-binary-path": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-1.0.1.tgz",
-			"integrity": "sha1-dfFmQrSA8YenEcgUFh/TpKdlWJg=",
-			"dev": true,
-			"optional": true,
-			"dependencies": {
-				"binary-extensions": "^1.0.0"
-			},
-			"engines": {
-				"node": ">=0.10.0"
 			}
 		},
 		"node_modules/is-boolean-object": {
@@ -23144,21 +23101,6 @@
 				"util-deprecate": "~1.0.1"
 			}
 		},
-		"node_modules/readdirp": {
-			"version": "2.2.1",
-			"resolved": "https://registry.npmjs.org/readdirp/-/readdirp-2.2.1.tgz",
-			"integrity": "sha512-1JU/8q+VgFZyxwrJ+SVIOsh+KywWGpds3NTqikiKpDMZWScmAYyKIgqkO+ARvNWJfXeXR1zxz7aHF4u4CyH6vQ==",
-			"dev": true,
-			"optional": true,
-			"dependencies": {
-				"graceful-fs": "^4.1.11",
-				"micromatch": "^3.1.10",
-				"readable-stream": "^2.0.2"
-			},
-			"engines": {
-				"node": ">=0.10"
-			}
-		},
 		"node_modules/rechoir": {
 			"version": "0.7.1",
 			"resolved": "https://registry.npmjs.org/rechoir/-/rechoir-0.7.1.tgz",
@@ -27279,17 +27221,6 @@
 				"node": ">=0.10.0"
 			}
 		},
-		"node_modules/upath": {
-			"version": "1.2.0",
-			"resolved": "https://registry.npmjs.org/upath/-/upath-1.2.0.tgz",
-			"integrity": "sha512-aZwGpamFO61g3OlfT7OQCHqhGnW43ieH9WZeP7QxN/G/jS4jfqUkZxoryvJgVPEcrl5NL/ggHsSmLMHuH64Lhg==",
-			"dev": true,
-			"optional": true,
-			"engines": {
-				"node": ">=4",
-				"yarn": "*"
-			}
-		},
 		"node_modules/uri-js": {
 			"version": "4.4.1",
 			"resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
@@ -27359,9 +27290,9 @@
 			}
 		},
 		"node_modules/use-deep-compare-effect": {
-			"version": "1.6.1",
-			"resolved": "https://registry.npmjs.org/use-deep-compare-effect/-/use-deep-compare-effect-1.6.1.tgz",
-			"integrity": "sha512-VB3b+7tFI81dHm8buGyrpxi8yBhzYZdyMX9iBJra7SMFMZ4ci4FJ1vFc1nvChiB1iLv4GfjqaYfvbNEpTT1rFQ==",
+			"version": "1.8.0",
+			"resolved": "https://registry.npmjs.org/use-deep-compare-effect/-/use-deep-compare-effect-1.8.0.tgz",
+			"integrity": "sha512-bWLtV110l0uXhe6KHArzpBMzhe8g202gcPypP+qXr9js8tCjNkewnYXhpUAaqtLAJhWDwa5Z+OtfaTOsiKO8dQ==",
 			"dependencies": {
 				"@babel/runtime": "^7.12.5",
 				"@types/react": "^17.0.0",
@@ -28699,12 +28630,12 @@
 	},
 	"dependencies": {
 		"@babel/cli": {
-			"version": "7.15.4",
-			"resolved": "https://registry.npmjs.org/@babel/cli/-/cli-7.15.4.tgz",
-			"integrity": "sha512-9RhhQ7tgKRcSO/jI3rNLxalLSk30cHqeM8bb+nGOJTyYBDpkoXw/A9QHZ2SYjlslAt4tr90pZQGIEobwWHSIDw==",
+			"version": "7.15.7",
+			"resolved": "https://registry.npmjs.org/@babel/cli/-/cli-7.15.7.tgz",
+			"integrity": "sha512-YW5wOprO2LzMjoWZ5ZG6jfbY9JnkDxuHDwvnrThnuYtByorova/I0HNXJedrUfwuXFQfYOjcqDA4PU3qlZGZjg==",
 			"dev": true,
 			"requires": {
-				"@nicolo-ribaudo/chokidar-2": "2.1.8-no-fsevents.2",
+				"@nicolo-ribaudo/chokidar-2": "2.1.8-no-fsevents.3",
 				"chokidar": "^3.4.0",
 				"commander": "^4.0.1",
 				"convert-source-map": "^1.1.0",
@@ -30845,24 +30776,11 @@
 			}
 		},
 		"@nicolo-ribaudo/chokidar-2": {
-			"version": "2.1.8-no-fsevents.2",
-			"resolved": "https://registry.npmjs.org/@nicolo-ribaudo/chokidar-2/-/chokidar-2-2.1.8-no-fsevents.2.tgz",
-			"integrity": "sha512-Fb8WxUFOBQVl+CX4MWet5o7eCc6Pj04rXIwVKZ6h1NnqTo45eOQW6aWyhG25NIODvWFwTDMwBsYxrQ3imxpetg==",
+			"version": "2.1.8-no-fsevents.3",
+			"resolved": "https://registry.npmjs.org/@nicolo-ribaudo/chokidar-2/-/chokidar-2-2.1.8-no-fsevents.3.tgz",
+			"integrity": "sha512-s88O1aVtXftvp5bCPB7WnmXc5IwOZZ7YPuwNPt+GtOOXpPvad1LfbmjYv+qII7zP6RU2QGnqve27dnLycEnyEQ==",
 			"dev": true,
-			"optional": true,
-			"requires": {
-				"anymatch": "^2.0.0",
-				"async-each": "^1.0.1",
-				"braces": "^2.3.2",
-				"glob-parent": "^5.1.2",
-				"inherits": "^2.0.3",
-				"is-binary-path": "^1.0.0",
-				"is-glob": "^4.0.0",
-				"normalize-path": "^3.0.0",
-				"path-is-absolute": "^1.0.0",
-				"readdirp": "^2.2.1",
-				"upath": "^1.1.1"
-			}
+			"optional": true
 		},
 		"@nodelib/fs.scandir": {
 			"version": "2.1.5",
@@ -33416,13 +33334,6 @@
 				"lodash": "^4.17.14"
 			}
 		},
-		"async-each": {
-			"version": "1.0.3",
-			"resolved": "https://registry.npmjs.org/async-each/-/async-each-1.0.3.tgz",
-			"integrity": "sha512-z/WhQ5FPySLdvREByI2vZiTWwCnF0moMJ1hK9YQwDTHKh6I7/uSckMetoRGb5UBZPC1z0jlw+n/XCgjeH7y1AQ==",
-			"dev": true,
-			"optional": true
-		},
 		"async-limiter": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/async-limiter/-/async-limiter-1.0.1.tgz",
@@ -33814,13 +33725,6 @@
 			"resolved": "https://registry.npmjs.org/big.js/-/big.js-5.2.2.tgz",
 			"integrity": "sha512-vyL2OymJxmarO8gxMr0mhChsO9QGwhynfuu4+MHTAW6czfq9humCB7rKpUjDd9YUiDPU4mzpyupFSvOClAwbmQ==",
 			"dev": true
-		},
-		"binary-extensions": {
-			"version": "1.13.1",
-			"resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-1.13.1.tgz",
-			"integrity": "sha512-Un7MIEDdUC5gNpcGDV97op1Ywk748MpHcFTHoYs6qnj1Z3j7I53VG3nwZhKzoBZmbdRNnb6WRdFlwl7tSDuZGw==",
-			"dev": true,
-			"optional": true
 		},
 		"bl": {
 			"version": "4.1.0",
@@ -39789,16 +39693,6 @@
 			"dev": true,
 			"requires": {
 				"has-bigints": "^1.0.1"
-			}
-		},
-		"is-binary-path": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-1.0.1.tgz",
-			"integrity": "sha1-dfFmQrSA8YenEcgUFh/TpKdlWJg=",
-			"dev": true,
-			"optional": true,
-			"requires": {
-				"binary-extensions": "^1.0.0"
 			}
 		},
 		"is-boolean-object": {
@@ -46289,18 +46183,6 @@
 				"util-deprecate": "~1.0.1"
 			}
 		},
-		"readdirp": {
-			"version": "2.2.1",
-			"resolved": "https://registry.npmjs.org/readdirp/-/readdirp-2.2.1.tgz",
-			"integrity": "sha512-1JU/8q+VgFZyxwrJ+SVIOsh+KywWGpds3NTqikiKpDMZWScmAYyKIgqkO+ARvNWJfXeXR1zxz7aHF4u4CyH6vQ==",
-			"dev": true,
-			"optional": true,
-			"requires": {
-				"graceful-fs": "^4.1.11",
-				"micromatch": "^3.1.10",
-				"readable-stream": "^2.0.2"
-			}
-		},
 		"rechoir": {
 			"version": "0.7.1",
 			"resolved": "https://registry.npmjs.org/rechoir/-/rechoir-0.7.1.tgz",
@@ -49512,13 +49394,6 @@
 				}
 			}
 		},
-		"upath": {
-			"version": "1.2.0",
-			"resolved": "https://registry.npmjs.org/upath/-/upath-1.2.0.tgz",
-			"integrity": "sha512-aZwGpamFO61g3OlfT7OQCHqhGnW43ieH9WZeP7QxN/G/jS4jfqUkZxoryvJgVPEcrl5NL/ggHsSmLMHuH64Lhg==",
-			"dev": true,
-			"optional": true
-		},
 		"uri-js": {
 			"version": "4.4.1",
 			"resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
@@ -49563,9 +49438,9 @@
 			"integrity": "sha512-cwESVXlO3url9YWlFW/TA9cshCEhtu7IKJ/p5soJ/gGpj7vbvFrAY/eIioQ6Dw23KjZhYgiIo8HOs1nQ2vr/oQ=="
 		},
 		"use-deep-compare-effect": {
-			"version": "1.6.1",
-			"resolved": "https://registry.npmjs.org/use-deep-compare-effect/-/use-deep-compare-effect-1.6.1.tgz",
-			"integrity": "sha512-VB3b+7tFI81dHm8buGyrpxi8yBhzYZdyMX9iBJra7SMFMZ4ci4FJ1vFc1nvChiB1iLv4GfjqaYfvbNEpTT1rFQ==",
+			"version": "1.8.0",
+			"resolved": "https://registry.npmjs.org/use-deep-compare-effect/-/use-deep-compare-effect-1.8.0.tgz",
+			"integrity": "sha512-bWLtV110l0uXhe6KHArzpBMzhe8g202gcPypP+qXr9js8tCjNkewnYXhpUAaqtLAJhWDwa5Z+OtfaTOsiKO8dQ==",
 			"requires": {
 				"@babel/runtime": "^7.12.5",
 				"@types/react": "^17.0.0",

--- a/package.json
+++ b/package.json
@@ -48,10 +48,10 @@
 		"@wordpress/i18n": "^4.2.2",
 		"@wordpress/url": "^3.2.2",
 		"react-geocode": "^0.2.3",
-		"use-deep-compare-effect": "^1.6.1"
+		"use-deep-compare-effect": "^1.8.0"
 	},
 	"devDependencies": {
-		"@babel/cli": "^7.15.4",
+		"@babel/cli": "^7.15.7",
 		"@babel/core": "^7.15.5",
 		"@babel/preset-env": "^7.15.6",
 		"@babel/preset-react": "7.14.5",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@sixa/wp-react-hooks",
-	"version": "1.3.0",
+	"version": "1.4.0",
 	"description": "A collection of most used React hooks crafted for the sixa projects.",
 	"keywords": [
 		"gutenberg",

--- a/src/index.js
+++ b/src/index.js
@@ -4,6 +4,8 @@ export { default as useDidMount } from './useDidMount';
 export { default as useDidUpdate } from './useDidUpdate';
 export { default as useGetNodeList } from './useGetNodeList';
 export { default as useGetPosts } from './useGetPosts';
+export { default as useGetProducts } from './useGetProducts';
+export { default as useGetProductTerms } from './useGetProductTerms';
 export { default as useGetTerms } from './useGetTerms';
 export { default as useInputValue } from './useInputValue';
 export { default as useLatLngBounds } from './useLatLngBounds';

--- a/src/useGetPosts/index.js
+++ b/src/useGetPosts/index.js
@@ -37,6 +37,13 @@ import useDeepCompareEffect from 'use-deep-compare-effect';
 import useToast from '../useToast';
 
 /**
+ * Toggling the value of the state.
+ *
+ * @ignore
+ */
+import useToggle from '../useToggle';
+
+/**
  * API connection interface for setting and receiveing API key.
  *
  * @ignore
@@ -48,7 +55,7 @@ import { apiClient } from '../utils';
  * this list when any of the direct arguments changed.
  *
  * @function
- * @since      1.2.0
+ * @since      1.4.0
  * @param      {Object}    args    	   Arguments to be passed to the apiFetch method.
  * @param      {string}    clientId    The block’s client id.
  * @param      {string}    postType    Post type name.
@@ -60,22 +67,26 @@ import { apiClient } from '../utils';
 function useGetPosts( args = {}, clientId, postType ) {
 	const [ options, setOptions ] = useState( [] );
 	const [ query, setQuery ] = useState( '' );
+	const [ loading, setLoading ] = useToggle();
 	const toast = useToast();
 
 	useDeepCompareEffect( () => {
+		setLoading();
 		apiClient
 			.get( `/wp/v2/${ postType }`, { per_page: -1, post_status: 'publish', ...args } )
 			.then( ( data ) => {
 				setOptions( selectOptions( data, { id: 'value', 'title.rendered': 'label' }, [] ) );
 				setQuery( data );
+				setLoading();
 			} )
 			.catch( () => {
 				setQuery( [] );
+				setLoading();
 				toast( __( 'Error: Couldn’t retrieve posts via API.', 'sixa' ), 'error' );
 			} );
 	}, [ args, clientId ] );
 
-	return { postsOptions: options, postsQuery: query };
+	return { isLoading: loading, postsOptions: options, postsQuery: query };
 }
 
 export default useGetPosts;

--- a/src/useGetProductTerms/index.js
+++ b/src/useGetProductTerms/index.js
@@ -1,0 +1,79 @@
+/**
+ * Utility for libraries from the `Lodash`.
+ *
+ * @ignore
+ */
+import { map, pick } from 'lodash';
+
+/**
+ * Retrieves the translation of text.
+ *
+ * @see    https://developer.wordpress.org/block-editor/packages/packages-i18n/
+ * @ignore
+ */
+import { __ } from '@wordpress/i18n';
+
+/**
+ * WordPress specific abstraction layer atop React.
+ *
+ * @see    https://github.com/WordPress/gutenberg/tree/HEAD/packages/element/README.md
+ * @ignore
+ */
+import { useState } from '@wordpress/element';
+
+/**
+ * Function to be called when component is mounted.
+ *
+ * @ignore
+ */
+import useDidMount from '../useDidMount';
+
+/**
+ * Generate toast messages.
+ *
+ * @ignore
+ */
+import useToast from '../useToast';
+
+/**
+ * API connection interface for setting and receiveing API key.
+ *
+ * @ignore
+ */
+import { apiClient } from '../utils';
+
+/**
+ * Retrieve list of product taxonomy terms only invoked
+ * immediately after the Edit component is mounted.
+ *
+ * @function
+ * @since      1.4.0
+ * @param      {string}    taxonomy    Taxonomy name.
+ * @param      {Object}    args    	   Arguments to be passed to the apiFetch method.
+ * @return     {Object} 			   List of terms retrieved from the API along with a list of options to select from.
+ * @example
+ *
+ * const { termsOptions, termsQuery } = useGetTerms( 'categories' );
+ */
+function useGetProductTerms( taxonomy, args = {} ) {
+	const [ options, setOptions ] = useState( [] );
+	const [ query, setQuery ] = useState( '' );
+	const toast = useToast();
+
+	useDidMount( () => {
+		apiClient
+			.get( `/wc/v3/products/${ taxonomy }`, { per_page: -1, post_status: 'publish', ...args } )
+			.then( ( data ) => {
+				setOptions( map( data, ( term ) => pick( term, [ 'id', 'name', 'parent' ] ) ) );
+				setQuery( data );
+			} )
+			.catch( () => {
+				setQuery( [] );
+				toast( __( 'Error: Couldn’t retrieve taxonomy terms via API.', 'sixa' ), 'error' );
+			} );
+	} );
+
+	return { termsOptions: options, termsQuery: query };
+}
+
+export default useGetProductTerms;

--- a/src/useGetProductTerms/index.js
+++ b/src/useGetProductTerms/index.js
@@ -36,6 +36,13 @@ import useDidMount from '../useDidMount';
 import useToast from '../useToast';
 
 /**
+ * Toggling the value of the state.
+ *
+ * @ignore
+ */
+import useToggle from '../useToggle';
+
+/**
  * API connection interface for setting and receiveing API key.
  *
  * @ignore
@@ -58,22 +65,26 @@ import { apiClient } from '../utils';
 function useGetProductTerms( taxonomy, args = {} ) {
 	const [ options, setOptions ] = useState( [] );
 	const [ query, setQuery ] = useState( '' );
+	const [ loading, setLoading ] = useToggle();
 	const toast = useToast();
 
 	useDidMount( () => {
+		setLoading();
 		apiClient
 			.get( `/wc/v3/products/${ taxonomy }`, { per_page: -1, post_status: 'publish', ...args } )
 			.then( ( data ) => {
 				setOptions( map( data, ( term ) => pick( term, [ 'id', 'name', 'parent' ] ) ) );
 				setQuery( data );
+				setLoading();
 			} )
 			.catch( () => {
 				setQuery( [] );
+				setLoading();
 				toast( __( 'Error: Couldn’t retrieve taxonomy terms via API.', 'sixa' ), 'error' );
 			} );
 	} );
 
-	return { termsOptions: options, termsQuery: query };
+	return { isLoading: loading, termsOptions: options, termsQuery: query };
 }
 
 export default useGetProductTerms;

--- a/src/useGetProducts/index.js
+++ b/src/useGetProducts/index.js
@@ -1,0 +1,80 @@
+/**
+ * Utility helper methods specific for Sixa projects.
+ *
+ * @ignore
+ */
+import { selectOptions } from '@sixa/wp-block-utils';
+
+/**
+ * Retrieves the translation of text.
+ *
+ * @see    https://developer.wordpress.org/block-editor/packages/packages-i18n/
+ * @ignore
+ */
+import { __ } from '@wordpress/i18n';
+
+/**
+ * WordPress specific abstraction layer atop React.
+ *
+ * @see    https://github.com/WordPress/gutenberg/tree/HEAD/packages/element/README.md
+ * @ignore
+ */
+import { useState } from '@wordpress/element';
+
+/**
+ * React hook to make deep comparison on the inputs, not reference equality.
+ *
+ * @see    https://github.com/kentcdodds/use-deep-compare-effect
+ * @ignore
+ */
+import useDeepCompareEffect from 'use-deep-compare-effect';
+
+/**
+ * Generate toast messages.
+ *
+ * @ignore
+ */
+import useToast from '../useToast';
+
+/**
+ * API connection interface for setting and receiveing API key.
+ *
+ * @ignore
+ */
+import { apiClient } from '../utils';
+
+/**
+ * Retrieve list of product posts and maintain refreshing
+ * this list when any of the direct arguments changed.
+ *
+ * @function
+ * @since      1.4.0
+ * @param      {Object}    args    	   Arguments to be passed to the apiFetch method.
+ * @param      {string}    clientId    The block’s client id.
+ * @return     {Object} 			   List of posts retrieved from the API along with a list of options to select from.
+ * @example
+ *
+ * const { productsOptions, productsQuery } = useGetProducts( { order: 'asc' }, clientId );
+ */
+function useGetProducts( args = {}, clientId ) {
+	const [ options, setOptions ] = useState( [] );
+	const [ query, setQuery ] = useState( '' );
+	const toast = useToast();
+
+	useDeepCompareEffect( () => {
+		apiClient
+			.get( '/wc/v3/products', { per_page: -1, status: 'publish', ...args } )
+			.then( ( data ) => {
+				setOptions( selectOptions( data, { id: 'value', name: 'label' }, [] ) );
+				setQuery( data );
+			} )
+			.catch( () => {
+				setQuery( [] );
+				toast( __( 'Error: Couldn’t retrieve products via API.', 'sixa' ), 'error' );
+			} );
+	}, [ args, clientId ] );
+
+	return { productsOptions: options, productsQuery: query };
+}
+
+export default useGetProducts;

--- a/src/useGetProducts/index.js
+++ b/src/useGetProducts/index.js
@@ -37,6 +37,13 @@ import useDeepCompareEffect from 'use-deep-compare-effect';
 import useToast from '../useToast';
 
 /**
+ * Toggling the value of the state.
+ *
+ * @ignore
+ */
+import useToggle from '../useToggle';
+
+/**
  * API connection interface for setting and receiveing API key.
  *
  * @ignore
@@ -59,22 +66,26 @@ import { apiClient } from '../utils';
 function useGetProducts( args = {}, clientId ) {
 	const [ options, setOptions ] = useState( [] );
 	const [ query, setQuery ] = useState( '' );
+	const [ loading, setLoading ] = useToggle();
 	const toast = useToast();
 
 	useDeepCompareEffect( () => {
+		setLoading();
 		apiClient
 			.get( '/wc/v3/products', { per_page: -1, status: 'publish', ...args } )
 			.then( ( data ) => {
 				setOptions( selectOptions( data, { id: 'value', name: 'label' }, [] ) );
 				setQuery( data );
+				setLoading();
 			} )
 			.catch( () => {
 				setQuery( [] );
+				setLoading();
 				toast( __( 'Error: Couldn’t retrieve products via API.', 'sixa' ), 'error' );
 			} );
 	}, [ args, clientId ] );
 
-	return { productsOptions: options, productsQuery: query };
+	return { isLoading: loading, productsOptions: options, productsQuery: query };
 }
 
 export default useGetProducts;

--- a/src/useGetTerms/index.js
+++ b/src/useGetTerms/index.js
@@ -36,6 +36,13 @@ import useDidMount from '../useDidMount';
 import useToast from '../useToast';
 
 /**
+ * Toggling the value of the state.
+ *
+ * @ignore
+ */
+import useToggle from '../useToggle';
+
+/**
  * API connection interface for setting and receiveing API key.
  *
  * @ignore
@@ -47,7 +54,7 @@ import { apiClient } from '../utils';
  * immediately after the Edit component is mounted.
  *
  * @function
- * @since      1.2.0
+ * @since      1.4.0
  * @param      {string}    taxonomy    Taxonomy name.
  * @param      {Object}    args    	   Arguments to be passed to the apiFetch method.
  * @return     {Object} 			   List of terms retrieved from the API along with a list of options to select from.
@@ -58,22 +65,26 @@ import { apiClient } from '../utils';
 function useGetTerms( taxonomy, args = {} ) {
 	const [ options, setOptions ] = useState( [] );
 	const [ query, setQuery ] = useState( '' );
+	const [ loading, setLoading ] = useToggle();
 	const toast = useToast();
 
 	useDidMount( () => {
+		setLoading();
 		apiClient
 			.get( `/wp/v2/${ taxonomy }`, { per_page: -1, post_status: 'publish', ...args } )
 			.then( ( data ) => {
 				setOptions( map( data, ( term ) => pick( term, [ 'id', 'name', 'parent' ] ) ) );
 				setQuery( data );
+				setLoading();
 			} )
 			.catch( () => {
 				setQuery( [] );
+				setLoading();
 				toast( __( 'Error: Couldn’t retrieve taxonomy terms via API.', 'sixa' ), 'error' );
 			} );
 	} );
 
-	return { termsOptions: options, termsQuery: query };
+	return { isLoading: loading, termsOptions: options, termsQuery: query };
 }
 
 export default useGetTerms;


### PR DESCRIPTION
This PR proposes new WooCommerce specific hooks to retrieve products and taxonomy terms using REST-API.

- `useGetProducts`: Retrieve a list of product posts.
- `useGetProductTerms`: Retrieve a list of product taxonomy terms.