### PR TITLE
Refresh state for taxonomy hooks

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "@sixa/wp-react-hooks",
-	"version": "1.4.0",
+	"version": "1.4.1",
 	"lockfileVersion": 2,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "@sixa/wp-react-hooks",
-			"version": "1.4.0",
+			"version": "1.4.1",
 			"license": "GPL-3.0-or-later",
 			"dependencies": {
 				"@wordpress/api-fetch": "^5.2.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@sixa/wp-react-hooks",
-	"version": "1.4.0",
+	"version": "1.4.1",
 	"description": "A collection of most used React hooks crafted for the sixa projects.",
 	"keywords": [
 		"gutenberg",

--- a/src/useGetProductTerms/index.js
+++ b/src/useGetProductTerms/index.js
@@ -22,11 +22,12 @@ import { __ } from '@wordpress/i18n';
 import { useState } from '@wordpress/element';
 
 /**
- * Function to be called when component is mounted.
+ * React hook to make deep comparison on the inputs, not reference equality.
  *
+ * @see    https://github.com/kentcdodds/use-deep-compare-effect
  * @ignore
  */
-import useDidMount from '../useDidMount';
+import useDeepCompareEffect from 'use-deep-compare-effect';
 
 /**
  * Generate toast messages.
@@ -50,17 +51,17 @@ import useToggle from '../useToggle';
 import { apiClient } from '../utils';
 
 /**
- * Retrieve list of product taxonomy terms only invoked
- * immediately after the Edit component is mounted.
+ * Retrieve list of product taxonomy terms and maintain refreshing
+ * this list when any of the direct arguments changed.
  *
  * @function
- * @since      1.4.0
+ * @since      1.4.1
  * @param      {string}    taxonomy    Taxonomy name.
  * @param      {Object}    args    	   Arguments to be passed to the apiFetch method.
  * @return     {Object} 			   List of terms retrieved from the API along with a list of options to select from.
  * @example
  *
- * const { termsOptions, termsQuery } = useGetTerms( 'categories' );
+ * const { termsOptions, termsQuery } = useGetProductTerms( 'categories' );
  */
 function useGetProductTerms( taxonomy, args = {} ) {
 	const [ options, setOptions ] = useState( [] );
@@ -68,7 +69,7 @@ function useGetProductTerms( taxonomy, args = {} ) {
 	const [ loading, setLoading ] = useToggle();
 	const toast = useToast();
 
-	useDidMount( () => {
+	useDeepCompareEffect( () => {
 		setLoading();
 		apiClient
 			.get( `/wc/v3/products/${ taxonomy }`, { per_page: -1, post_status: 'publish', ...args } )
@@ -82,7 +83,7 @@ function useGetProductTerms( taxonomy, args = {} ) {
 				setLoading();
 				toast( __( 'Error: Couldn’t retrieve taxonomy terms via API.', 'sixa' ), 'error' );
 			} );
-	} );
+	}, [ args ] );
 
 	return { isLoading: loading, termsOptions: options, termsQuery: query };
 }

--- a/src/useGetTerms/index.js
+++ b/src/useGetTerms/index.js
@@ -22,11 +22,12 @@ import { __ } from '@wordpress/i18n';
 import { useState } from '@wordpress/element';
 
 /**
- * Function to be called when component is mounted.
+ * React hook to make deep comparison on the inputs, not reference equality.
  *
+ * @see    https://github.com/kentcdodds/use-deep-compare-effect
  * @ignore
  */
-import useDidMount from '../useDidMount';
+import useDeepCompareEffect from 'use-deep-compare-effect';
 
 /**
  * Generate toast messages.
@@ -50,11 +51,11 @@ import useToggle from '../useToggle';
 import { apiClient } from '../utils';
 
 /**
- * Retrieve list of taxonomy terms only invoked
- * immediately after the Edit component is mounted.
+ * Retrieve list of taxonomy terms and maintain refreshing
+ * this list when any of the direct arguments changed.
  *
  * @function
- * @since      1.4.0
+ * @since      1.4.1
  * @param      {string}    taxonomy    Taxonomy name.
  * @param      {Object}    args    	   Arguments to be passed to the apiFetch method.
  * @return     {Object} 			   List of terms retrieved from the API along with a list of options to select from.
@@ -68,7 +69,7 @@ function useGetTerms( taxonomy, args = {} ) {
 	const [ loading, setLoading ] = useToggle();
 	const toast = useToast();
 
-	useDidMount( () => {
+	useDeepCompareEffect( () => {
 		setLoading();
 		apiClient
 			.get( `/wp/v2/${ taxonomy }`, { per_page: -1, post_status: 'publish', ...args } )
@@ -82,7 +83,7 @@ function useGetTerms( taxonomy, args = {} ) {
 				setLoading();
 				toast( __( 'Error: Couldn’t retrieve taxonomy terms via API.', 'sixa' ), 'error' );
 			} );
-	} );
+	}, [ args ] );
 
 	return { isLoading: loading, termsOptions: options, termsQuery: query };
 }


### PR DESCRIPTION
This PR proposes adding state maintenance to taxonomy hooks by refreshing the already cached query when any direct arguments change.