### PR TITLE
Babel ES Module

### DIFF
--- a/babel.config.js
+++ b/babel.config.js
@@ -1,5 +1,5 @@
 module.exports = {
-	presets: [ '@babel/preset-env', '@babel/preset-react' ],
+	presets: [ [ '@babel/preset-env', { modules: false } ], '@babel/preset-react' ],
 	minified: true,
 	comments: false,
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,11 +9,13 @@
 			"version": "1.4.1",
 			"license": "GPL-3.0-or-later",
 			"dependencies": {
+				"@sixa/wp-block-utils": "^1.0.4",
 				"@wordpress/api-fetch": "^5.2.2",
 				"@wordpress/data": "^6.1.0",
 				"@wordpress/element": "^4.0.1",
 				"@wordpress/i18n": "^4.2.2",
 				"@wordpress/url": "^3.2.2",
+				"lodash": "4.17.21",
 				"react-geocode": "^0.2.3",
 				"use-deep-compare-effect": "^1.6.1"
 			},
@@ -22,14 +24,12 @@
 				"@babel/core": "^7.15.5",
 				"@babel/preset-env": "^7.15.6",
 				"@babel/preset-react": "7.14.5",
-				"@sixa/wp-block-utils": "1.0.4-beta.0",
 				"@wordpress/scripts": "^18.0.1",
 				"babel-loader": "8.2.2",
 				"cross-env": "7.0.3",
 				"documentation": "13.2.5",
 				"husky": "^7.0.2",
-				"lint-staged": "11.1.2",
-				"lodash": "4.17.21"
+				"lint-staged": "11.1.2"
 			}
 		},
 		"node_modules/@babel/cli": {
@@ -3939,11 +3939,12 @@
 			}
 		},
 		"node_modules/@sixa/wp-block-utils": {
-			"version": "1.0.4-beta.0",
-			"resolved": "https://registry.npmjs.org/@sixa/wp-block-utils/-/wp-block-utils-1.0.4-beta.0.tgz",
-			"integrity": "sha512-Fv1D9wCuaQTdCOZGxPTpdvUIUNzN+EkebRKEq46hOMlXOzUvHz1a//kvSpzu6BUFdxX5pt9ab1vLGB6U47XqtA==",
-			"dev": true,
+			"version": "1.0.4",
+			"resolved": "https://registry.npmjs.org/@sixa/wp-block-utils/-/wp-block-utils-1.0.4.tgz",
+			"integrity": "sha512-ha8AVqLerV90i9jCmJ82dN5hFEzNE+UpwtV4Pi10mPleU6xIZEmzkKYgi+rV+9UXM6xFb6l6jGf4V+3+mWcViA==",
 			"dependencies": {
+				"classnames": "2.3.1",
+				"lodash": "4.17.21",
 				"rename-keys": "^2.0.1",
 				"slugify": "^1.6.0",
 				"striptags": "^3.2.0"
@@ -5407,7 +5408,6 @@
 			"version": "3.2.1",
 			"resolved": "https://registry.npmjs.org/@wordpress/html-entities/-/html-entities-3.2.1.tgz",
 			"integrity": "sha512-DHuIQ7MMyAcmkMM/VY8RibIcLiIcstk6Og09f4EWQegOgage6yMgnG7eI0nf2LBe65mttnda1EL51slc7XjaXg==",
-			"dev": true,
 			"peer": true,
 			"dependencies": {
 				"@babel/runtime": "^7.13.10"
@@ -7616,6 +7616,11 @@
 			"engines": {
 				"node": ">=0.10.0"
 			}
+		},
+		"node_modules/classnames": {
+			"version": "2.3.1",
+			"resolved": "https://registry.npmjs.org/classnames/-/classnames-2.3.1.tgz",
+			"integrity": "sha512-OlQdbZ7gLfGarSqxesMesDa5uz7KFbID8Kpq/SxIoNGDqY8lSYs0D+hhtBXhcdB3rcbXArFr7vlHheLk1voeNA=="
 		},
 		"node_modules/clean-stack": {
 			"version": "2.2.0",
@@ -23466,7 +23471,6 @@
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/rename-keys/-/rename-keys-2.0.1.tgz",
 			"integrity": "sha512-WOWHR9dTgGZPp+mPS0IYKIXr9+JR8dqgmTmOlu3CP5egUXAuQ4n07SGv7hZ9VURYVdkU2khkMcLYWcv3mSROEg==",
-			"dev": true,
 			"dependencies": {
 				"isobject": "^3.0.1"
 			},
@@ -24328,7 +24332,6 @@
 			"version": "1.6.0",
 			"resolved": "https://registry.npmjs.org/slugify/-/slugify-1.6.0.tgz",
 			"integrity": "sha512-FkMq+MQc5hzYgM86nLuHI98Acwi3p4wX+a5BO9Hhw4JdK4L7WueIiZ4tXEobImPqBz2sVcV0+Mu3GRB30IGang==",
-			"dev": true,
 			"engines": {
 				"node": ">=8.0.0"
 			}
@@ -25321,8 +25324,7 @@
 		"node_modules/striptags": {
 			"version": "3.2.0",
 			"resolved": "https://registry.npmjs.org/striptags/-/striptags-3.2.0.tgz",
-			"integrity": "sha512-g45ZOGzHDMe2bdYMdIvdAfCQkCTDMGBazSw1ypMowwGIee7ZQ5dU0rBJ8Jqgl+jAKIv4dbeE1jscZq9wid1Tkw==",
-			"dev": true
+			"integrity": "sha512-g45ZOGzHDMe2bdYMdIvdAfCQkCTDMGBazSw1ypMowwGIee7ZQ5dU0rBJ8Jqgl+jAKIv4dbeE1jscZq9wid1Tkw=="
 		},
 		"node_modules/style-search": {
 			"version": "0.1.0",
@@ -31562,11 +31564,12 @@
 			}
 		},
 		"@sixa/wp-block-utils": {
-			"version": "1.0.4-beta.0",
-			"resolved": "https://registry.npmjs.org/@sixa/wp-block-utils/-/wp-block-utils-1.0.4-beta.0.tgz",
-			"integrity": "sha512-Fv1D9wCuaQTdCOZGxPTpdvUIUNzN+EkebRKEq46hOMlXOzUvHz1a//kvSpzu6BUFdxX5pt9ab1vLGB6U47XqtA==",
-			"dev": true,
+			"version": "1.0.4",
+			"resolved": "https://registry.npmjs.org/@sixa/wp-block-utils/-/wp-block-utils-1.0.4.tgz",
+			"integrity": "sha512-ha8AVqLerV90i9jCmJ82dN5hFEzNE+UpwtV4Pi10mPleU6xIZEmzkKYgi+rV+9UXM6xFb6l6jGf4V+3+mWcViA==",
 			"requires": {
+				"classnames": "2.3.1",
+				"lodash": "4.17.21",
 				"rename-keys": "^2.0.1",
 				"slugify": "^1.6.0",
 				"striptags": "^3.2.0"
@@ -32727,7 +32730,6 @@
 			"version": "3.2.1",
 			"resolved": "https://registry.npmjs.org/@wordpress/html-entities/-/html-entities-3.2.1.tgz",
 			"integrity": "sha512-DHuIQ7MMyAcmkMM/VY8RibIcLiIcstk6Og09f4EWQegOgage6yMgnG7eI0nf2LBe65mttnda1EL51slc7XjaXg==",
-			"dev": true,
 			"peer": true,
 			"requires": {
 				"@babel/runtime": "^7.13.10"
@@ -34414,6 +34416,11 @@
 					}
 				}
 			}
+		},
+		"classnames": {
+			"version": "2.3.1",
+			"resolved": "https://registry.npmjs.org/classnames/-/classnames-2.3.1.tgz",
+			"integrity": "sha512-OlQdbZ7gLfGarSqxesMesDa5uz7KFbID8Kpq/SxIoNGDqY8lSYs0D+hhtBXhcdB3rcbXArFr7vlHheLk1voeNA=="
 		},
 		"clean-stack": {
 			"version": "2.2.0",
@@ -46536,7 +46543,6 @@
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/rename-keys/-/rename-keys-2.0.1.tgz",
 			"integrity": "sha512-WOWHR9dTgGZPp+mPS0IYKIXr9+JR8dqgmTmOlu3CP5egUXAuQ4n07SGv7hZ9VURYVdkU2khkMcLYWcv3mSROEg==",
-			"dev": true,
 			"requires": {
 				"isobject": "^3.0.1"
 			}
@@ -47199,8 +47205,7 @@
 		"slugify": {
 			"version": "1.6.0",
 			"resolved": "https://registry.npmjs.org/slugify/-/slugify-1.6.0.tgz",
-			"integrity": "sha512-FkMq+MQc5hzYgM86nLuHI98Acwi3p4wX+a5BO9Hhw4JdK4L7WueIiZ4tXEobImPqBz2sVcV0+Mu3GRB30IGang==",
-			"dev": true
+			"integrity": "sha512-FkMq+MQc5hzYgM86nLuHI98Acwi3p4wX+a5BO9Hhw4JdK4L7WueIiZ4tXEobImPqBz2sVcV0+Mu3GRB30IGang=="
 		},
 		"snapdragon": {
 			"version": "0.8.2",
@@ -47994,8 +47999,7 @@
 		"striptags": {
 			"version": "3.2.0",
 			"resolved": "https://registry.npmjs.org/striptags/-/striptags-3.2.0.tgz",
-			"integrity": "sha512-g45ZOGzHDMe2bdYMdIvdAfCQkCTDMGBazSw1ypMowwGIee7ZQ5dU0rBJ8Jqgl+jAKIv4dbeE1jscZq9wid1Tkw==",
-			"dev": true
+			"integrity": "sha512-g45ZOGzHDMe2bdYMdIvdAfCQkCTDMGBazSw1ypMowwGIee7ZQ5dU0rBJ8Jqgl+jAKIv4dbeE1jscZq9wid1Tkw=="
 		},
 		"style-search": {
 			"version": "0.1.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "@sixa/wp-react-hooks",
-	"version": "1.4.0",
+	"version": "1.4.1-beta.1",
 	"lockfileVersion": 2,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "@sixa/wp-react-hooks",
-			"version": "1.4.0",
+			"version": "1.4.1-beta.1",
 			"license": "GPL-3.0-or-later",
 			"dependencies": {
 				"@wordpress/api-fetch": "^5.2.2",
@@ -22,7 +22,7 @@
 				"@babel/core": "^7.15.5",
 				"@babel/preset-env": "^7.15.6",
 				"@babel/preset-react": "7.14.5",
-				"@sixa/wp-block-utils": "^1.0.3",
+				"@sixa/wp-block-utils": "1.0.4-beta.0",
 				"@wordpress/scripts": "^18.0.1",
 				"babel-loader": "8.2.2",
 				"cross-env": "7.0.3",
@@ -3939,9 +3939,9 @@
 			}
 		},
 		"node_modules/@sixa/wp-block-utils": {
-			"version": "1.0.3",
-			"resolved": "https://registry.npmjs.org/@sixa/wp-block-utils/-/wp-block-utils-1.0.3.tgz",
-			"integrity": "sha512-H3n49nnML0oJ5i8nj43T990sEiDLykSKB9vZuJyHEgoyKxCx7PBqglWSXpCvNKg47EcUTjy+InZc1iEsc3o+QQ==",
+			"version": "1.0.4-beta.0",
+			"resolved": "https://registry.npmjs.org/@sixa/wp-block-utils/-/wp-block-utils-1.0.4-beta.0.tgz",
+			"integrity": "sha512-Fv1D9wCuaQTdCOZGxPTpdvUIUNzN+EkebRKEq46hOMlXOzUvHz1a//kvSpzu6BUFdxX5pt9ab1vLGB6U47XqtA==",
 			"dev": true,
 			"dependencies": {
 				"rename-keys": "^2.0.1",
@@ -31562,9 +31562,9 @@
 			}
 		},
 		"@sixa/wp-block-utils": {
-			"version": "1.0.3",
-			"resolved": "https://registry.npmjs.org/@sixa/wp-block-utils/-/wp-block-utils-1.0.3.tgz",
-			"integrity": "sha512-H3n49nnML0oJ5i8nj43T990sEiDLykSKB9vZuJyHEgoyKxCx7PBqglWSXpCvNKg47EcUTjy+InZc1iEsc3o+QQ==",
+			"version": "1.0.4-beta.0",
+			"resolved": "https://registry.npmjs.org/@sixa/wp-block-utils/-/wp-block-utils-1.0.4-beta.0.tgz",
+			"integrity": "sha512-Fv1D9wCuaQTdCOZGxPTpdvUIUNzN+EkebRKEq46hOMlXOzUvHz1a//kvSpzu6BUFdxX5pt9ab1vLGB6U47XqtA==",
 			"dev": true,
 			"requires": {
 				"rename-keys": "^2.0.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "@sixa/wp-react-hooks",
-	"version": "1.4.1-beta.1",
+	"version": "1.4.1",
 	"lockfileVersion": 2,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "@sixa/wp-react-hooks",
-			"version": "1.4.1-beta.1",
+			"version": "1.4.1",
 			"license": "GPL-3.0-or-later",
 			"dependencies": {
 				"@wordpress/api-fetch": "^5.2.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@sixa/wp-react-hooks",
-	"version": "1.4.1-beta.1",
+	"version": "1.4.1",
 	"description": "A collection of most used React hooks crafted for the sixa projects.",
 	"keywords": [
 		"gutenberg",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@sixa/wp-react-hooks",
-	"version": "1.4.0",
+	"version": "1.4.1-beta.1",
 	"description": "A collection of most used React hooks crafted for the sixa projects.",
 	"keywords": [
 		"gutenberg",
@@ -55,7 +55,7 @@
 		"@babel/core": "^7.15.5",
 		"@babel/preset-env": "^7.15.6",
 		"@babel/preset-react": "7.14.5",
-		"@sixa/wp-block-utils": "^1.0.3",
+		"@sixa/wp-block-utils": "1.0.4-beta.0",
 		"@wordpress/scripts": "^18.0.1",
 		"babel-loader": "8.2.2",
 		"cross-env": "7.0.3",

--- a/package.json
+++ b/package.json
@@ -42,27 +42,27 @@
 		]
 	},
 	"dependencies": {
+		"@sixa/wp-block-utils": "^1.0.4",
 		"@wordpress/api-fetch": "^5.2.2",
 		"@wordpress/data": "^6.1.0",
 		"@wordpress/element": "^4.0.1",
 		"@wordpress/i18n": "^4.2.2",
 		"@wordpress/url": "^3.2.2",
 		"react-geocode": "^0.2.3",
-		"use-deep-compare-effect": "^1.6.1"
+		"use-deep-compare-effect": "^1.6.1",
+		"lodash": "4.17.21"
 	},
 	"devDependencies": {
 		"@babel/cli": "^7.15.4",
 		"@babel/core": "^7.15.5",
 		"@babel/preset-env": "^7.15.6",
 		"@babel/preset-react": "7.14.5",
-		"@sixa/wp-block-utils": "1.0.4-beta.0",
 		"@wordpress/scripts": "^18.0.1",
 		"babel-loader": "8.2.2",
 		"cross-env": "7.0.3",
 		"documentation": "13.2.5",
 		"husky": "^7.0.2",
-		"lint-staged": "11.1.2",
-		"lodash": "4.17.21"
+		"lint-staged": "11.1.2"
 	},
 	"publishConfig": {
 		"access": "public"


### PR DESCRIPTION
This PR proposes to use `{ modules: false }` in `@babel/preset-env` to enable webpack tree shaking. In addition, I have moved production dependencies from `devDependencies` to `dependencies`.