### PR TITLE
Deep compare viewport values - useVisibilityClassNames ⚓ :big

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "@sixa/wp-react-hooks",
-	"version": "1.6.2",
+	"version": "1.6.3",
 	"lockfileVersion": 2,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "@sixa/wp-react-hooks",
-			"version": "1.6.2",
+			"version": "1.6.3",
 			"license": "GPL-3.0-or-later",
 			"dependencies": {
 				"@sixa/wp-block-utils": "^1.0.4",
@@ -22,14 +22,14 @@
 			"devDependencies": {
 				"@babel/cli": "^7.16.0",
 				"@babel/core": "^7.16.0",
-				"@babel/preset-env": "7.16.4",
+				"@babel/preset-env": "^7.16.4",
 				"@babel/preset-react": "^7.16.0",
-				"@wordpress/scripts": "^19.2.1",
+				"@wordpress/scripts": "^19.2.2",
 				"babel-loader": "^8.2.3",
 				"cross-env": "7.0.3",
 				"documentation": "13.2.5",
 				"husky": "^7.0.4",
-				"lint-staged": "12.0.2",
+				"lint-staged": "^12.1.2",
 				"prettier": "npm:wp-prettier@^2.2.1-beta-1"
 			}
 		},
@@ -4225,9 +4225,9 @@
 			}
 		},
 		"node_modules/@wordpress/base-styles": {
-			"version": "4.0.3",
-			"resolved": "https://registry.npmjs.org/@wordpress/base-styles/-/base-styles-4.0.3.tgz",
-			"integrity": "sha512-dL6xsQUeCNY7oqNDbbO9k65bOXq4zKwFfdJQITXUIuH3PBVoZaonsndeV8BsRs7I5YXiJCqT1ts6gjibJr914g==",
+			"version": "4.0.4",
+			"resolved": "https://registry.npmjs.org/@wordpress/base-styles/-/base-styles-4.0.4.tgz",
+			"integrity": "sha512-qXiIhWLdTHWxBWawcqigJUUMeb2jkn9ElUEUC/Cn3DK2i62jiUWXOLp6tFIaf5eQMNXsYqtp5r7n2F/OllngQA==",
 			"dev": true
 		},
 		"node_modules/@wordpress/browserslist-config": {
@@ -4534,12 +4534,12 @@
 			}
 		},
 		"node_modules/@wordpress/postcss-plugins-preset": {
-			"version": "3.2.4",
-			"resolved": "https://registry.npmjs.org/@wordpress/postcss-plugins-preset/-/postcss-plugins-preset-3.2.4.tgz",
-			"integrity": "sha512-YFoV+rtBgoWYnW82iQCL5BwYzDPEE0aVNs33IkKV5X+eu7w730q+nyN7th+N4DOYdgApCgi9At2LLMAqTDtwwQ==",
+			"version": "3.2.5",
+			"resolved": "https://registry.npmjs.org/@wordpress/postcss-plugins-preset/-/postcss-plugins-preset-3.2.5.tgz",
+			"integrity": "sha512-R+UKnjSJivvVEZ8rhGrXxsj/BlVeNO2FRXq3IxEOPv5ZRfAS0g8k8EO3xsCIV1RfnozvAApkKEYRClDYXIt+vA==",
 			"dev": true,
 			"dependencies": {
-				"@wordpress/base-styles": "^4.0.3",
+				"@wordpress/base-styles": "^4.0.4",
 				"autoprefixer": "^10.2.5"
 			},
 			"engines": {
@@ -4582,9 +4582,9 @@
 			}
 		},
 		"node_modules/@wordpress/scripts": {
-			"version": "19.2.1",
-			"resolved": "https://registry.npmjs.org/@wordpress/scripts/-/scripts-19.2.1.tgz",
-			"integrity": "sha512-BIdCeCwPGQDlkfOR4THcxdiGMK7l27qbv1/n8OkqUcdDi9GICm3TnWeqzRgpw45j6GK0OCEvSjSjQi65kV1/Dw==",
+			"version": "19.2.2",
+			"resolved": "https://registry.npmjs.org/@wordpress/scripts/-/scripts-19.2.2.tgz",
+			"integrity": "sha512-cH1NVhBKScNHIHXc3Af7FBOdsZBrA72IJVcZwUx79/BJVEhPVG3B9Kn4xkXP9RtYCkWETQ+s/KodzolL9RuHmQ==",
 			"dev": true,
 			"dependencies": {
 				"@svgr/webpack": "^5.5.0",
@@ -4594,7 +4594,7 @@
 				"@wordpress/eslint-plugin": "^9.3.0",
 				"@wordpress/jest-preset-default": "^7.1.3",
 				"@wordpress/npm-package-json-lint-config": "^4.1.0",
-				"@wordpress/postcss-plugins-preset": "^3.2.4",
+				"@wordpress/postcss-plugins-preset": "^3.2.5",
 				"@wordpress/prettier-config": "^1.1.1",
 				"@wordpress/stylelint-config": "^19.1.0",
 				"babel-jest": "^26.6.3",
@@ -15977,9 +15977,9 @@
 			}
 		},
 		"node_modules/lilconfig": {
-			"version": "2.0.3",
-			"resolved": "https://registry.npmjs.org/lilconfig/-/lilconfig-2.0.3.tgz",
-			"integrity": "sha512-EHKqr/+ZvdKCifpNrJCKxBTgk5XupZA3y/aCPY9mxfgBzmgh93Mt/WqjjQ38oMxXuvDokaKiM3lAgvSH2sjtHg==",
+			"version": "2.0.4",
+			"resolved": "https://registry.npmjs.org/lilconfig/-/lilconfig-2.0.4.tgz",
+			"integrity": "sha512-bfTIN7lEsiooCocSISTWXkiWJkRqtL9wYtYy+8EK3Y41qh3mpwPU0ycTOgjdY9ErwXCc8QyrQp82bdL0Xkm9yA==",
 			"dev": true,
 			"engines": {
 				"node": ">=10"
@@ -16001,23 +16001,25 @@
 			}
 		},
 		"node_modules/lint-staged": {
-			"version": "12.0.2",
-			"resolved": "https://registry.npmjs.org/lint-staged/-/lint-staged-12.0.2.tgz",
-			"integrity": "sha512-tpCvACqc7bykziGJmXG0G8YG2RaCrWiDBwmrP9wU7i/3za9JMOvCECQmXjw/sO4ICC70ApVwyqixS1htQX9Haw==",
+			"version": "12.1.2",
+			"resolved": "https://registry.npmjs.org/lint-staged/-/lint-staged-12.1.2.tgz",
+			"integrity": "sha512-bSMcQVqMW98HLLLR2c2tZ+vnDCnx4fd+0QJBQgN/4XkdspGRPc8DGp7UuOEBe1ApCfJ+wXXumYnJmU+wDo7j9A==",
 			"dev": true,
 			"dependencies": {
-				"cli-truncate": "3.1.0",
+				"cli-truncate": "^3.1.0",
 				"colorette": "^2.0.16",
 				"commander": "^8.3.0",
-				"cosmiconfig": "^7.0.1",
 				"debug": "^4.3.2",
+				"enquirer": "^2.3.6",
 				"execa": "^5.1.1",
+				"lilconfig": "2.0.4",
 				"listr2": "^3.13.3",
 				"micromatch": "^4.0.4",
 				"normalize-path": "^3.0.0",
-				"object-inspect": "1.11.0",
-				"string-argv": "0.3.1",
-				"supports-color": "9.0.2"
+				"object-inspect": "^1.11.0",
+				"string-argv": "^0.3.1",
+				"supports-color": "^9.0.2",
+				"yaml": "^1.10.2"
 			},
 			"bin": {
 				"lint-staged": "bin/lint-staged.js"
@@ -28862,9 +28864,9 @@
 			}
 		},
 		"@wordpress/base-styles": {
-			"version": "4.0.3",
-			"resolved": "https://registry.npmjs.org/@wordpress/base-styles/-/base-styles-4.0.3.tgz",
-			"integrity": "sha512-dL6xsQUeCNY7oqNDbbO9k65bOXq4zKwFfdJQITXUIuH3PBVoZaonsndeV8BsRs7I5YXiJCqT1ts6gjibJr914g==",
+			"version": "4.0.4",
+			"resolved": "https://registry.npmjs.org/@wordpress/base-styles/-/base-styles-4.0.4.tgz",
+			"integrity": "sha512-qXiIhWLdTHWxBWawcqigJUUMeb2jkn9ElUEUC/Cn3DK2i62jiUWXOLp6tFIaf5eQMNXsYqtp5r7n2F/OllngQA==",
 			"dev": true
 		},
 		"@wordpress/browserslist-config": {
@@ -29086,12 +29088,12 @@
 			"requires": {}
 		},
 		"@wordpress/postcss-plugins-preset": {
-			"version": "3.2.4",
-			"resolved": "https://registry.npmjs.org/@wordpress/postcss-plugins-preset/-/postcss-plugins-preset-3.2.4.tgz",
-			"integrity": "sha512-YFoV+rtBgoWYnW82iQCL5BwYzDPEE0aVNs33IkKV5X+eu7w730q+nyN7th+N4DOYdgApCgi9At2LLMAqTDtwwQ==",
+			"version": "3.2.5",
+			"resolved": "https://registry.npmjs.org/@wordpress/postcss-plugins-preset/-/postcss-plugins-preset-3.2.5.tgz",
+			"integrity": "sha512-R+UKnjSJivvVEZ8rhGrXxsj/BlVeNO2FRXq3IxEOPv5ZRfAS0g8k8EO3xsCIV1RfnozvAApkKEYRClDYXIt+vA==",
 			"dev": true,
 			"requires": {
-				"@wordpress/base-styles": "^4.0.3",
+				"@wordpress/base-styles": "^4.0.4",
 				"autoprefixer": "^10.2.5"
 			}
 		},
@@ -29122,9 +29124,9 @@
 			}
 		},
 		"@wordpress/scripts": {
-			"version": "19.2.1",
-			"resolved": "https://registry.npmjs.org/@wordpress/scripts/-/scripts-19.2.1.tgz",
-			"integrity": "sha512-BIdCeCwPGQDlkfOR4THcxdiGMK7l27qbv1/n8OkqUcdDi9GICm3TnWeqzRgpw45j6GK0OCEvSjSjQi65kV1/Dw==",
+			"version": "19.2.2",
+			"resolved": "https://registry.npmjs.org/@wordpress/scripts/-/scripts-19.2.2.tgz",
+			"integrity": "sha512-cH1NVhBKScNHIHXc3Af7FBOdsZBrA72IJVcZwUx79/BJVEhPVG3B9Kn4xkXP9RtYCkWETQ+s/KodzolL9RuHmQ==",
 			"dev": true,
 			"requires": {
 				"@svgr/webpack": "^5.5.0",
@@ -29134,7 +29136,7 @@
 				"@wordpress/eslint-plugin": "^9.3.0",
 				"@wordpress/jest-preset-default": "^7.1.3",
 				"@wordpress/npm-package-json-lint-config": "^4.1.0",
-				"@wordpress/postcss-plugins-preset": "^3.2.4",
+				"@wordpress/postcss-plugins-preset": "^3.2.5",
 				"@wordpress/prettier-config": "^1.1.1",
 				"@wordpress/stylelint-config": "^19.1.0",
 				"babel-jest": "^26.6.3",
@@ -37786,9 +37788,9 @@
 			}
 		},
 		"lilconfig": {
-			"version": "2.0.3",
-			"resolved": "https://registry.npmjs.org/lilconfig/-/lilconfig-2.0.3.tgz",
-			"integrity": "sha512-EHKqr/+ZvdKCifpNrJCKxBTgk5XupZA3y/aCPY9mxfgBzmgh93Mt/WqjjQ38oMxXuvDokaKiM3lAgvSH2sjtHg==",
+			"version": "2.0.4",
+			"resolved": "https://registry.npmjs.org/lilconfig/-/lilconfig-2.0.4.tgz",
+			"integrity": "sha512-bfTIN7lEsiooCocSISTWXkiWJkRqtL9wYtYy+8EK3Y41qh3mpwPU0ycTOgjdY9ErwXCc8QyrQp82bdL0Xkm9yA==",
 			"dev": true
 		},
 		"lines-and-columns": {
@@ -37807,23 +37809,25 @@
 			}
 		},
 		"lint-staged": {
-			"version": "12.0.2",
-			"resolved": "https://registry.npmjs.org/lint-staged/-/lint-staged-12.0.2.tgz",
-			"integrity": "sha512-tpCvACqc7bykziGJmXG0G8YG2RaCrWiDBwmrP9wU7i/3za9JMOvCECQmXjw/sO4ICC70ApVwyqixS1htQX9Haw==",
+			"version": "12.1.2",
+			"resolved": "https://registry.npmjs.org/lint-staged/-/lint-staged-12.1.2.tgz",
+			"integrity": "sha512-bSMcQVqMW98HLLLR2c2tZ+vnDCnx4fd+0QJBQgN/4XkdspGRPc8DGp7UuOEBe1ApCfJ+wXXumYnJmU+wDo7j9A==",
 			"dev": true,
 			"requires": {
-				"cli-truncate": "3.1.0",
+				"cli-truncate": "^3.1.0",
 				"colorette": "^2.0.16",
 				"commander": "^8.3.0",
-				"cosmiconfig": "^7.0.1",
 				"debug": "^4.3.2",
+				"enquirer": "^2.3.6",
 				"execa": "^5.1.1",
+				"lilconfig": "2.0.4",
 				"listr2": "^3.13.3",
 				"micromatch": "^4.0.4",
 				"normalize-path": "^3.0.0",
-				"object-inspect": "1.11.0",
-				"string-argv": "0.3.1",
-				"supports-color": "9.0.2"
+				"object-inspect": "^1.11.0",
+				"string-argv": "^0.3.1",
+				"supports-color": "^9.0.2",
+				"yaml": "^1.10.2"
 			},
 			"dependencies": {
 				"ansi-regex": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@sixa/wp-react-hooks",
-	"version": "1.6.2",
+	"version": "1.6.3",
 	"description": "A collection of most used React hooks crafted for the sixa projects.",
 	"keywords": [
 		"sixa",
@@ -56,14 +56,14 @@
 	"devDependencies": {
 		"@babel/cli": "^7.16.0",
 		"@babel/core": "^7.16.0",
-		"@babel/preset-env": "7.16.4",
+		"@babel/preset-env": "^7.16.4",
 		"@babel/preset-react": "^7.16.0",
-		"@wordpress/scripts": "^19.2.1",
+		"@wordpress/scripts": "^19.2.2",
 		"babel-loader": "^8.2.3",
 		"cross-env": "7.0.3",
 		"documentation": "13.2.5",
 		"husky": "^7.0.4",
-		"lint-staged": "12.0.2",
+		"lint-staged": "^12.1.2",
 		"prettier": "npm:wp-prettier@^2.2.1-beta-1"
 	},
 	"publishConfig": {

--- a/src/useVisibilityClassNames/index.js
+++ b/src/useVisibilityClassNames/index.js
@@ -14,11 +14,12 @@ import { identity, map, pickBy } from 'lodash';
 import { useState } from '@wordpress/element';
 
 /**
- * Function to be called when component is updated.
+ * React hook to make deep comparison on the inputs, not reference equality.
  *
+ * @see    https://github.com/kentcdodds/use-deep-compare-effect
  * @ignore
  */
-import useDidUpdate from '../useDidUpdate';
+import useDeepCompareEffect from 'use-deep-compare-effect';
 
 /**
  * Generates CSS class names for activated viewports.
@@ -36,7 +37,7 @@ const getVisibilityClassNames = ( { prefix = 'sixa-hide-', ...viewports } ) =>
  * and returns a list of visibility (breakpoint) CSS class names.
  *
  * @function
- * @since      1.6.0
+ * @since      1.6.3
  * @param  	   {Object}    viewports    An object of breakpoints with their state of visibility being defined.
  * @return     {Array}                  Returns a list of visibility CSS class names.
  * @example
@@ -48,7 +49,7 @@ const getVisibilityClassNames = ( { prefix = 'sixa-hide-', ...viewports } ) =>
 function useVisibilityClassNames( viewports ) {
 	const [ classNames, setClassNames ] = useState( () => getVisibilityClassNames( viewports ) );
 
-	useDidUpdate( () => {
+	useDeepCompareEffect( () => {
 		setClassNames( getVisibilityClassNames( viewports ) );
 	}, [ viewports ] );
 


### PR DESCRIPTION
This PR aims to avoid updating state in the `useVisibilityClassNames` hook when no viewport or CSS class name prefix is updated by deep comparing object values with their previous state.