### PR TITLE
useColumnsProps 🪝

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,23 +1,23 @@
 {
 	"name": "@sixa/wp-react-hooks",
-	"version": "1.7.0",
+	"version": "1.8.0",
 	"lockfileVersion": 2,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "@sixa/wp-react-hooks",
-			"version": "1.7.0",
+			"version": "1.8.0",
 			"license": "GPL-3.0-or-later",
 			"dependencies": {
-				"@sixa/wp-block-utils": "^1.0.4",
-				"@wordpress/api-fetch": "^5.2.6",
-				"@wordpress/data": "^6.1.4",
-				"@wordpress/element": "^4.0.4",
-				"@wordpress/i18n": "^4.2.4",
-				"@wordpress/url": "^3.3.1",
+				"@sixa/wp-block-utils": "1.0.4",
+				"@wordpress/api-fetch": "5.2.6",
+				"@wordpress/data": "6.1.4",
+				"@wordpress/element": "4.0.4",
+				"@wordpress/i18n": "4.2.4",
+				"@wordpress/url": "3.3.1",
 				"lodash": "4.17.21",
-				"react-geocode": "^0.2.3",
-				"use-deep-compare-effect": "^1.8.1"
+				"react-geocode": "0.2.3",
+				"use-deep-compare-effect": "1.8.1"
 			},
 			"devDependencies": {
 				"@babel/cli": "7.16.0",
@@ -28,7 +28,7 @@
 				"babel-loader": "8.2.3",
 				"cross-env": "7.0.3",
 				"documentation": "13.2.5",
-				"husky": "^7.0.4",
+				"husky": "7.0.4",
 				"lint-staged": "12.1.2",
 				"prettier": "npm:wp-prettier@2.2.1-beta-1"
 			}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@sixa/wp-react-hooks",
-	"version": "1.7.0",
+	"version": "1.8.0",
 	"description": "A collection of most used React hooks crafted for the sixa projects.",
 	"keywords": [
 		"sixa",
@@ -43,15 +43,15 @@
 		]
 	},
 	"dependencies": {
-		"@sixa/wp-block-utils": "^1.0.4",
-		"@wordpress/api-fetch": "^5.2.6",
-		"@wordpress/data": "^6.1.4",
-		"@wordpress/element": "^4.0.4",
-		"@wordpress/i18n": "^4.2.4",
-		"@wordpress/url": "^3.3.1",
+		"@sixa/wp-block-utils": "1.0.4",
+		"@wordpress/api-fetch": "5.2.6",
+		"@wordpress/data": "6.1.4",
+		"@wordpress/element": "4.0.4",
+		"@wordpress/i18n": "4.2.4",
+		"@wordpress/url": "3.3.1",
 		"lodash": "4.17.21",
-		"react-geocode": "^0.2.3",
-		"use-deep-compare-effect": "^1.8.1"
+		"react-geocode": "0.2.3",
+		"use-deep-compare-effect": "1.8.1"
 	},
 	"devDependencies": {
 		"@babel/cli": "7.16.0",
@@ -62,7 +62,7 @@
 		"babel-loader": "8.2.3",
 		"cross-env": "7.0.3",
 		"documentation": "13.2.5",
-		"husky": "^7.0.4",
+		"husky": "7.0.4",
 		"lint-staged": "12.1.2",
 		"prettier": "npm:wp-prettier@2.2.1-beta-1"
 	},

--- a/src/index.js
+++ b/src/index.js
@@ -1,4 +1,5 @@
 export { default as useActiveTab } from './useActiveTab';
+export { default as useColumnsProps } from './useColumnsProps';
 export { default as useConditionalRef } from './useConditionalRef';
 export { default as useDidMount } from './useDidMount';
 export { default as useDidUpdate } from './useDidUpdate';

--- a/src/useColumnsProps/index.js
+++ b/src/useColumnsProps/index.js
@@ -1,0 +1,72 @@
+/**
+ * Utility for libraries from the `Lodash`.
+ *
+ * @ignore
+ */
+import { isNumber, map, pickBy } from 'lodash';
+
+/**
+ * WordPress specific abstraction layer atop React.
+ *
+ * @see    https://developer.wordpress.org/block-editor/reference-guides/packages/packages-element/
+ * @ignore
+ */
+import { useState } from '@wordpress/element';
+
+/**
+ * React hook to make deep comparison on the inputs, not reference equality.
+ *
+ * @see    https://github.com/kentcdodds/use-deep-compare-effect
+ * @ignore
+ */
+import useDeepCompareEffect from 'use-deep-compare-effect';
+
+/**
+ * Generates CSS class names for activated viewports.
+ *
+ * @ignore
+ */
+const getColumnsProps = ( { prefix = 'sixa-columns-', columns, gap } ) => ( {
+	className: map(
+		pickBy( columns, ( column ) => isNumber( column ) ),
+		( number, viewport ) => prefix + `${ number }-${ viewport }`
+	),
+	style: {
+		'--columns-gap': gap,
+	},
+} );
+
+/**
+ * This hook maintains the state of each Columns viewport
+ * and returns a list of Columns (breakpoint) CSS class names
+ * along with inline CSS style for the gap range defined viewport-wide.
+ *
+ * @function
+ * @since      1.8.0
+ * @param  	   {Object}    props    An object of breakpoints for columns and viewport-wide gap (gutter) value.
+ * @return     {Object}             Returns an object of CSS class names and inline style object.
+ * @example
+ *
+ * const { className, style } = useColumnsProps( { columns: { widescreen: 4, laptop: 4, tablet: 2, mobile: 1 }, gap: '0px' } );
+ *
+ * // className => Array  [ 'sixa-columns-5-widescreen', 'sixa-columns-4-laptop', 'sixa-columns-2-tablet', 'sixa-columns-1-mobile' ]
+ * // style 	=> Object { '--columns-gap': '20px' }
+ */
+function useColumnsProps( props ) {
+	const [ columnsProps, setColumnsProps ] = useState( () => getColumnsProps( props ) );
+
+	useDeepCompareEffect( () => {
+		setColumnsProps( getColumnsProps( props ) );
+	}, [ props ] );
+
+	return columnsProps;
+}
+
+export default useColumnsProps;
+
+/**
+ * Call within a save function to get the class names for the block wrapper.
+ *
+ * @ignore
+ */
+useColumnsProps.save = getColumnsProps;


### PR DESCRIPTION
This PR introduces a new hook responsible for maintaining and generating CSS class names and viewport-wide columns gap inline CSS style according to the properties given.