### PR TITLE
usePostTypeNameRestBase 🪝

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -2,7 +2,7 @@
 <html lang="en">
 <head>
   <meta charset='utf-8'>
-  <title>@sixa/wp-react-hooks 1.8.0 | Documentation</title>
+  <title>@sixa/wp-react-hooks 1.9.0 | Documentation</title>
   <meta name='description' content='A collection of most used React hooks crafted for the sixa projects.'>
   <meta name='viewport' content='width=device-width,initial-scale=1'>
   <link href='assets/bass.css' rel='stylesheet'>
@@ -15,7 +15,7 @@
       <div id='split-left' class='overflow-auto fs0 height-viewport-100'>
         <div class='py1 px2'>
           <h3 class='mb0 no-anchor'>@sixa/wp-react-hooks</h3>
-          <div class='mb1'><code>1.8.0</code></div>
+          <div class='mb1'><code>1.9.0</code></div>
           <input
             placeholder='Filter'
             id='filter-input'
@@ -199,6 +199,16 @@
               
                 
                 <li><a
+                  href='#useposttypenamerestbase'
+                  class="">
+                  usePostTypeNameRestBase
+                  
+                </a>
+                
+                </li>
+              
+                
+                <li><a
                   href='#useprepareposts'
                   class="">
                   usePreparePosts
@@ -257,7 +267,7 @@
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/sixach/wp-react-hooks/blob/63bf17c20dd2f2a55b94a0d507461dda9bbeb957/src/useActiveTab/index.js#L28-L31'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/sixach/wp-react-hooks/blob/cf4ff9016a9e31c0967e79b54959f38c9a944d37/src/useActiveTab/index.js#L28-L31'>
       <span>src/useActiveTab/index.js</span>
       </a>
     
@@ -348,7 +358,7 @@
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/sixach/wp-react-hooks/blob/63bf17c20dd2f2a55b94a0d507461dda9bbeb957/src/useColumnsProps/index.js#L55-L63'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/sixach/wp-react-hooks/blob/cf4ff9016a9e31c0967e79b54959f38c9a944d37/src/useColumnsProps/index.js#L55-L63'>
       <span>src/useColumnsProps/index.js</span>
       </a>
     
@@ -435,7 +445,7 @@ along with inline CSS style for the gap range defined viewport-wide.</p>
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/sixach/wp-react-hooks/blob/63bf17c20dd2f2a55b94a0d507461dda9bbeb957/src/useConditionalRef/index.js#L21-L34'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/sixach/wp-react-hooks/blob/cf4ff9016a9e31c0967e79b54959f38c9a944d37/src/useConditionalRef/index.js#L21-L34'>
       <span>src/useConditionalRef/index.js</span>
       </a>
     
@@ -529,7 +539,7 @@ along with inline CSS style for the gap range defined viewport-wide.</p>
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/sixach/wp-react-hooks/blob/63bf17c20dd2f2a55b94a0d507461dda9bbeb957/src/useDidMount/index.js#L29-L35'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/sixach/wp-react-hooks/blob/cf4ff9016a9e31c0967e79b54959f38c9a944d37/src/useDidMount/index.js#L29-L35'>
       <span>src/useDidMount/index.js</span>
       </a>
     
@@ -612,7 +622,7 @@ along with inline CSS style for the gap range defined viewport-wide.</p>
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/sixach/wp-react-hooks/blob/63bf17c20dd2f2a55b94a0d507461dda9bbeb957/src/useDidUpdate/index.js#L25-L35'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/sixach/wp-react-hooks/blob/cf4ff9016a9e31c0967e79b54959f38c9a944d37/src/useDidUpdate/index.js#L25-L35'>
       <span>src/useDidUpdate/index.js</span>
       </a>
     
@@ -707,7 +717,7 @@ conditions to fire callback when one of the conditions changes.</p>
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/sixach/wp-react-hooks/blob/63bf17c20dd2f2a55b94a0d507461dda9bbeb957/src/useFindPostById/index.js#L29-L37'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/sixach/wp-react-hooks/blob/cf4ff9016a9e31c0967e79b54959f38c9a944d37/src/useFindPostById/index.js#L29-L37'>
       <span>src/useFindPostById/index.js</span>
       </a>
     
@@ -799,7 +809,7 @@ and maintains the state of change when it happens.</p>
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/sixach/wp-react-hooks/blob/63bf17c20dd2f2a55b94a0d507461dda9bbeb957/src/useToast/index.js#L21-L26'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/sixach/wp-react-hooks/blob/cf4ff9016a9e31c0967e79b54959f38c9a944d37/src/useToast/index.js#L21-L26'>
       <span>src/useToast/index.js</span>
       </a>
     
@@ -868,7 +878,7 @@ toast( <span class="hljs-string">&#x27;Text to display as a toast message!&#x27;
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/sixach/wp-react-hooks/blob/63bf17c20dd2f2a55b94a0d507461dda9bbeb957/src/useGetNodeList/index.js#L51-L68'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/sixach/wp-react-hooks/blob/cf4ff9016a9e31c0967e79b54959f38c9a944d37/src/useGetNodeList/index.js#L51-L68'>
       <span>src/useGetNodeList/index.js</span>
       </a>
     
@@ -960,7 +970,7 @@ toast( <span class="hljs-string">&#x27;Text to display as a toast message!&#x27;
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/sixach/wp-react-hooks/blob/63bf17c20dd2f2a55b94a0d507461dda9bbeb957/src/useGetPostMeta/index.js#L28-L40'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/sixach/wp-react-hooks/blob/cf4ff9016a9e31c0967e79b54959f38c9a944d37/src/useGetPostMeta/index.js#L28-L40'>
       <span>src/useGetPostMeta/index.js</span>
       </a>
     
@@ -1042,7 +1052,7 @@ toast( <span class="hljs-string">&#x27;Text to display as a toast message!&#x27;
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/sixach/wp-react-hooks/blob/63bf17c20dd2f2a55b94a0d507461dda9bbeb957/src/useToggle/index.js#L30-L32'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/sixach/wp-react-hooks/blob/cf4ff9016a9e31c0967e79b54959f38c9a944d37/src/useToggle/index.js#L30-L32'>
       <span>src/useToggle/index.js</span>
       </a>
     
@@ -1136,7 +1146,7 @@ toast( <span class="hljs-string">&#x27;Text to display as a toast message!&#x27;
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/sixach/wp-react-hooks/blob/63bf17c20dd2f2a55b94a0d507461dda9bbeb957/src/useGetPosts/index.js#L67-L90'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/sixach/wp-react-hooks/blob/cf4ff9016a9e31c0967e79b54959f38c9a944d37/src/useGetPosts/index.js#L67-L90'>
       <span>src/useGetPosts/index.js</span>
       </a>
     
@@ -1238,7 +1248,7 @@ this list when any of the direct arguments changed.</p>
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/sixach/wp-react-hooks/blob/63bf17c20dd2f2a55b94a0d507461dda9bbeb957/src/useGetProducts/index.js#L66-L89'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/sixach/wp-react-hooks/blob/cf4ff9016a9e31c0967e79b54959f38c9a944d37/src/useGetProducts/index.js#L66-L89'>
       <span>src/useGetProducts/index.js</span>
       </a>
     
@@ -1331,7 +1341,7 @@ this list when any of the direct arguments changed.</p>
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/sixach/wp-react-hooks/blob/63bf17c20dd2f2a55b94a0d507461dda9bbeb957/src/useGetProductTerms/index.js#L66-L89'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/sixach/wp-react-hooks/blob/cf4ff9016a9e31c0967e79b54959f38c9a944d37/src/useGetProductTerms/index.js#L66-L89'>
       <span>src/useGetProductTerms/index.js</span>
       </a>
     
@@ -1424,7 +1434,7 @@ this list when any of the direct arguments changed.</p>
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/sixach/wp-react-hooks/blob/63bf17c20dd2f2a55b94a0d507461dda9bbeb957/src/useGetTerms/index.js#L66-L89'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/sixach/wp-react-hooks/blob/cf4ff9016a9e31c0967e79b54959f38c9a944d37/src/useGetTerms/index.js#L66-L89'>
       <span>src/useGetTerms/index.js</span>
       </a>
     
@@ -1517,7 +1527,7 @@ this list when any of the direct arguments changed.</p>
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/sixach/wp-react-hooks/blob/63bf17c20dd2f2a55b94a0d507461dda9bbeb957/src/useInputValue/index.js#L22-L29'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/sixach/wp-react-hooks/blob/cf4ff9016a9e31c0967e79b54959f38c9a944d37/src/useInputValue/index.js#L22-L29'>
       <span>src/useInputValue/index.js</span>
       </a>
     
@@ -1602,7 +1612,7 @@ and updates it when the <code>onChange</code> event raises.</p>
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/sixach/wp-react-hooks/blob/63bf17c20dd2f2a55b94a0d507461dda9bbeb957/src/useLatLngBounds/index.js#L44-L69'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/sixach/wp-react-hooks/blob/cf4ff9016a9e31c0967e79b54959f38c9a944d37/src/useLatLngBounds/index.js#L44-L69'>
       <span>src/useLatLngBounds/index.js</span>
       </a>
     
@@ -1705,7 +1715,7 @@ and updates it when the <code>onChange</code> event raises.</p>
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/sixach/wp-react-hooks/blob/63bf17c20dd2f2a55b94a0d507461dda9bbeb957/src/useNormalizeJsonify/index.js#L21-L25'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/sixach/wp-react-hooks/blob/cf4ff9016a9e31c0967e79b54959f38c9a944d37/src/useNormalizeJsonify/index.js#L21-L25'>
       <span>src/useNormalizeJsonify/index.js</span>
       </a>
     
@@ -1785,12 +1795,95 @@ and updates it when the <code>onChange</code> event raises.</p>
   
   <div class='clearfix'>
     
+    <h3 class='fl m0' id='useposttypenamerestbase'>
+      usePostTypeNameRestBase
+    </h3>
+    
+    
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/sixach/wp-react-hooks/blob/cf4ff9016a9e31c0967e79b54959f38c9a944d37/src/usePostTypeNameRestBase/index.js#L41-L44'>
+      <span>src/usePostTypeNameRestBase/index.js</span>
+      </a>
+    
+  </div>
+  
+
+  <p>This hook maintains the state of post-type name and
+REST-API base key extraction from the given string value.</p>
+
+    <div class='pre p1 fill-light mt0'>usePostTypeNameRestBase(postType: <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String">string</a>): <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object">Object</a></div>
+  
+  
+
+  
+  
+  
+  
+  
+  <div>Since: 1.9.0</div>
+
+  
+    <div class='py1 quiet mt1 prose-big'>Parameters</div>
+    <div class='prose'>
+      
+        <div class='space-bottom0'>
+          <div>
+            <span class='code bold'>postType</span> <code class='quiet'>(<a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String">string</a>)</code>
+	    Post type name and rest-base key.
+
+          </div>
+          
+        </div>
+      
+    </div>
+  
+
+  
+
+  
+    
+      <div class='py1 quiet mt1 prose-big'>Returns</div>
+      <code><a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object">Object</a></code>:
+        Object of post-type name and REST-API base key.
+
+      
+    
+  
+
+  
+
+  
+
+  
+    <div class='py1 quiet mt1 prose-big'>Example</div>
+    
+      
+      <pre class='p1 overflow-auto round fill-light'><span class="hljs-keyword">const</span> { postTypeKey, restBaseKey } = usePostTypeNameRestBase( <span class="hljs-string">&#x27;post|posts&#x27;</span> );</pre>
+    
+  
+
+  
+
+  
+
+  
+
+  
+</section>
+
+          
+        
+          
+          <section class='p2 mb2 clearfix bg-white minishadow'>
+
+  
+  <div class='clearfix'>
+    
     <h3 class='fl m0' id='useprepareposts'>
       usePreparePosts
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/sixach/wp-react-hooks/blob/63bf17c20dd2f2a55b94a0d507461dda9bbeb957/src/usePreparePosts/index.js#L37-L48'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/sixach/wp-react-hooks/blob/cf4ff9016a9e31c0967e79b54959f38c9a944d37/src/usePreparePosts/index.js#L37-L48'>
       <span>src/usePreparePosts/index.js</span>
       </a>
     
@@ -1893,7 +1986,7 @@ and slices the query according to the maximum limit determined.</p>
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/sixach/wp-react-hooks/blob/63bf17c20dd2f2a55b94a0d507461dda9bbeb957/src/useTimeout/index.js#L23-L56'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/sixach/wp-react-hooks/blob/cf4ff9016a9e31c0967e79b54959f38c9a944d37/src/useTimeout/index.js#L23-L56'>
       <span>src/useTimeout/index.js</span>
       </a>
     
@@ -1987,7 +2080,7 @@ start();</pre>
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/sixach/wp-react-hooks/blob/63bf17c20dd2f2a55b94a0d507461dda9bbeb957/src/useUpdatePostMeta/index.js#L39-L51'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/sixach/wp-react-hooks/blob/cf4ff9016a9e31c0967e79b54959f38c9a944d37/src/useUpdatePostMeta/index.js#L39-L51'>
       <span>src/useUpdatePostMeta/index.js</span>
       </a>
     
@@ -2097,7 +2190,7 @@ start();</pre>
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/sixach/wp-react-hooks/blob/63bf17c20dd2f2a55b94a0d507461dda9bbeb957/src/useVisibilityClassNames/index.js#L49-L57'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/sixach/wp-react-hooks/blob/cf4ff9016a9e31c0967e79b54959f38c9a944d37/src/useVisibilityClassNames/index.js#L49-L57'>
       <span>src/useVisibilityClassNames/index.js</span>
       </a>
     

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "@sixa/wp-react-hooks",
-	"version": "1.8.0",
+	"version": "1.9.0",
 	"lockfileVersion": 2,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "@sixa/wp-react-hooks",
-			"version": "1.8.0",
+			"version": "1.9.0",
 			"license": "GPL-3.0-or-later",
 			"dependencies": {
 				"@sixa/wp-block-utils": "1.0.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@sixa/wp-react-hooks",
-	"version": "1.8.0",
+	"version": "1.9.0",
 	"description": "A collection of most used React hooks crafted for the sixa projects.",
 	"keywords": [
 		"sixa",

--- a/src/index.js
+++ b/src/index.js
@@ -13,6 +13,7 @@ export { default as useGetTerms } from './useGetTerms';
 export { default as useInputValue } from './useInputValue';
 export { default as useLatLngBounds } from './useLatLngBounds';
 export { default as useNormalizeJsonify } from './useNormalizeJsonify';
+export { default as usePostTypeNameRestBase } from './usePostTypeNameRestBase';
 export { default as usePreparePosts } from './usePreparePosts';
 export { default as useTimeout } from './useTimeout';
 export { default as useToast } from './useToast';

--- a/src/usePostTypeNameRestBase/index.js
+++ b/src/usePostTypeNameRestBase/index.js
@@ -1,0 +1,55 @@
+/**
+ * Utility for libraries from the `Lodash`.
+ *
+ * @ignore
+ */
+import { head, last, split } from 'lodash';
+
+/**
+ * WordPress specific abstraction layer atop React.
+ *
+ * @see    https://developer.wordpress.org/block-editor/reference-guides/packages/packages-element/
+ * @ignore
+ */
+import { useMemo } from '@wordpress/element';
+
+/**
+ * Separates post-type name from its REST-API base key.
+ *
+ * @ignore
+ */
+const getPostTypeNameRestBase = ( postType ) => {
+	const postTypeRestBase = split( postType, '|' );
+	return {
+		postTypeKey: head( postTypeRestBase ),
+		restBaseKey: last( postTypeRestBase ),
+	};
+};
+
+/**
+ * This hook maintains the state of post-type name and
+ * REST-API base key extraction from the given string value.
+ *
+ * @function
+ * @since      1.9.0
+ * @param      {string}    postType    Post type name and rest-base key.
+ * @return     {Object}    			   Object of post-type name and REST-API base key.
+ * @example
+ *
+ * const { postTypeKey, restBaseKey } = usePostTypeNameRestBase( 'post|posts' );
+ */
+function usePostTypeNameRestBase( postType ) {
+	const { postTypeKey, restBaseKey } = useMemo( () => getPostTypeNameRestBase( postType ), [ postType ] );
+	return { postTypeKey, restBaseKey };
+}
+
+export default usePostTypeNameRestBase;
+
+/**
+ * Allow this hook to be called within a save function as well.
+ * This is purely added to avoid `eslint` error since Gutenberg
+ * cannot process a React component for the Save output.
+ *
+ * @ignore
+ */
+usePostTypeNameRestBase.save = getPostTypeNameRestBase;


### PR DESCRIPTION
This PR introduces a new hook responsible for maintaining the state of post-type name and REST-API base key extraction from the given attribute value.