### PR TITLE
usePreparePosts undefined entries 🔴 

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,0 +1,8 @@
+module.exports = {
+	root: true,
+	extends: [ 'plugin:@wordpress/eslint-plugin/recommended' ],
+	rules: {
+		'jsdoc/check-line-alignment': 'off',
+		'no-nested-ternary': 'off',
+	},
+};

--- a/docs/index.html
+++ b/docs/index.html
@@ -2,7 +2,7 @@
 <html lang="en">
 <head>
   <meta charset='utf-8'>
-  <title>@sixa/wp-react-hooks 1.9.0 | Documentation</title>
+  <title>@sixa/wp-react-hooks 1.9.1 | Documentation</title>
   <meta name='description' content='A collection of most used React hooks crafted for the sixa projects.'>
   <meta name='viewport' content='width=device-width,initial-scale=1'>
   <link href='assets/bass.css' rel='stylesheet'>
@@ -15,7 +15,7 @@
       <div id='split-left' class='overflow-auto fs0 height-viewport-100'>
         <div class='py1 px2'>
           <h3 class='mb0 no-anchor'>@sixa/wp-react-hooks</h3>
-          <div class='mb1'><code>1.9.0</code></div>
+          <div class='mb1'><code>1.9.1</code></div>
           <input
             placeholder='Filter'
             id='filter-input'
@@ -267,7 +267,7 @@
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/sixach/wp-react-hooks/blob/cf4ff9016a9e31c0967e79b54959f38c9a944d37/src/useActiveTab/index.js#L28-L31'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/sixach/wp-react-hooks/blob/3720025802d2ac2b2fdf7137586de9493fdd673c/src/useActiveTab/index.js#L28-L31'>
       <span>src/useActiveTab/index.js</span>
       </a>
     
@@ -358,7 +358,7 @@
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/sixach/wp-react-hooks/blob/cf4ff9016a9e31c0967e79b54959f38c9a944d37/src/useColumnsProps/index.js#L55-L63'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/sixach/wp-react-hooks/blob/3720025802d2ac2b2fdf7137586de9493fdd673c/src/useColumnsProps/index.js#L55-L63'>
       <span>src/useColumnsProps/index.js</span>
       </a>
     
@@ -445,7 +445,7 @@ along with inline CSS style for the gap range defined viewport-wide.</p>
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/sixach/wp-react-hooks/blob/cf4ff9016a9e31c0967e79b54959f38c9a944d37/src/useConditionalRef/index.js#L21-L34'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/sixach/wp-react-hooks/blob/3720025802d2ac2b2fdf7137586de9493fdd673c/src/useConditionalRef/index.js#L21-L34'>
       <span>src/useConditionalRef/index.js</span>
       </a>
     
@@ -539,7 +539,7 @@ along with inline CSS style for the gap range defined viewport-wide.</p>
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/sixach/wp-react-hooks/blob/cf4ff9016a9e31c0967e79b54959f38c9a944d37/src/useDidMount/index.js#L29-L35'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/sixach/wp-react-hooks/blob/3720025802d2ac2b2fdf7137586de9493fdd673c/src/useDidMount/index.js#L29-L35'>
       <span>src/useDidMount/index.js</span>
       </a>
     
@@ -622,7 +622,7 @@ along with inline CSS style for the gap range defined viewport-wide.</p>
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/sixach/wp-react-hooks/blob/cf4ff9016a9e31c0967e79b54959f38c9a944d37/src/useDidUpdate/index.js#L25-L35'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/sixach/wp-react-hooks/blob/3720025802d2ac2b2fdf7137586de9493fdd673c/src/useDidUpdate/index.js#L25-L35'>
       <span>src/useDidUpdate/index.js</span>
       </a>
     
@@ -717,7 +717,7 @@ conditions to fire callback when one of the conditions changes.</p>
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/sixach/wp-react-hooks/blob/cf4ff9016a9e31c0967e79b54959f38c9a944d37/src/useFindPostById/index.js#L29-L37'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/sixach/wp-react-hooks/blob/3720025802d2ac2b2fdf7137586de9493fdd673c/src/useFindPostById/index.js#L29-L37'>
       <span>src/useFindPostById/index.js</span>
       </a>
     
@@ -809,7 +809,7 @@ and maintains the state of change when it happens.</p>
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/sixach/wp-react-hooks/blob/cf4ff9016a9e31c0967e79b54959f38c9a944d37/src/useToast/index.js#L21-L26'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/sixach/wp-react-hooks/blob/3720025802d2ac2b2fdf7137586de9493fdd673c/src/useToast/index.js#L21-L26'>
       <span>src/useToast/index.js</span>
       </a>
     
@@ -878,7 +878,7 @@ toast( <span class="hljs-string">&#x27;Text to display as a toast message!&#x27;
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/sixach/wp-react-hooks/blob/cf4ff9016a9e31c0967e79b54959f38c9a944d37/src/useGetNodeList/index.js#L51-L68'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/sixach/wp-react-hooks/blob/3720025802d2ac2b2fdf7137586de9493fdd673c/src/useGetNodeList/index.js#L51-L68'>
       <span>src/useGetNodeList/index.js</span>
       </a>
     
@@ -970,7 +970,7 @@ toast( <span class="hljs-string">&#x27;Text to display as a toast message!&#x27;
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/sixach/wp-react-hooks/blob/cf4ff9016a9e31c0967e79b54959f38c9a944d37/src/useGetPostMeta/index.js#L28-L40'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/sixach/wp-react-hooks/blob/3720025802d2ac2b2fdf7137586de9493fdd673c/src/useGetPostMeta/index.js#L28-L40'>
       <span>src/useGetPostMeta/index.js</span>
       </a>
     
@@ -1052,7 +1052,7 @@ toast( <span class="hljs-string">&#x27;Text to display as a toast message!&#x27;
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/sixach/wp-react-hooks/blob/cf4ff9016a9e31c0967e79b54959f38c9a944d37/src/useToggle/index.js#L30-L32'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/sixach/wp-react-hooks/blob/3720025802d2ac2b2fdf7137586de9493fdd673c/src/useToggle/index.js#L30-L32'>
       <span>src/useToggle/index.js</span>
       </a>
     
@@ -1146,7 +1146,7 @@ toast( <span class="hljs-string">&#x27;Text to display as a toast message!&#x27;
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/sixach/wp-react-hooks/blob/cf4ff9016a9e31c0967e79b54959f38c9a944d37/src/useGetPosts/index.js#L67-L90'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/sixach/wp-react-hooks/blob/3720025802d2ac2b2fdf7137586de9493fdd673c/src/useGetPosts/index.js#L67-L90'>
       <span>src/useGetPosts/index.js</span>
       </a>
     
@@ -1248,7 +1248,7 @@ this list when any of the direct arguments changed.</p>
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/sixach/wp-react-hooks/blob/cf4ff9016a9e31c0967e79b54959f38c9a944d37/src/useGetProducts/index.js#L66-L89'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/sixach/wp-react-hooks/blob/3720025802d2ac2b2fdf7137586de9493fdd673c/src/useGetProducts/index.js#L66-L89'>
       <span>src/useGetProducts/index.js</span>
       </a>
     
@@ -1341,7 +1341,7 @@ this list when any of the direct arguments changed.</p>
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/sixach/wp-react-hooks/blob/cf4ff9016a9e31c0967e79b54959f38c9a944d37/src/useGetProductTerms/index.js#L66-L89'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/sixach/wp-react-hooks/blob/3720025802d2ac2b2fdf7137586de9493fdd673c/src/useGetProductTerms/index.js#L66-L89'>
       <span>src/useGetProductTerms/index.js</span>
       </a>
     
@@ -1434,7 +1434,7 @@ this list when any of the direct arguments changed.</p>
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/sixach/wp-react-hooks/blob/cf4ff9016a9e31c0967e79b54959f38c9a944d37/src/useGetTerms/index.js#L66-L89'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/sixach/wp-react-hooks/blob/3720025802d2ac2b2fdf7137586de9493fdd673c/src/useGetTerms/index.js#L66-L89'>
       <span>src/useGetTerms/index.js</span>
       </a>
     
@@ -1527,7 +1527,7 @@ this list when any of the direct arguments changed.</p>
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/sixach/wp-react-hooks/blob/cf4ff9016a9e31c0967e79b54959f38c9a944d37/src/useInputValue/index.js#L22-L29'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/sixach/wp-react-hooks/blob/3720025802d2ac2b2fdf7137586de9493fdd673c/src/useInputValue/index.js#L22-L29'>
       <span>src/useInputValue/index.js</span>
       </a>
     
@@ -1612,7 +1612,7 @@ and updates it when the <code>onChange</code> event raises.</p>
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/sixach/wp-react-hooks/blob/cf4ff9016a9e31c0967e79b54959f38c9a944d37/src/useLatLngBounds/index.js#L44-L69'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/sixach/wp-react-hooks/blob/3720025802d2ac2b2fdf7137586de9493fdd673c/src/useLatLngBounds/index.js#L44-L69'>
       <span>src/useLatLngBounds/index.js</span>
       </a>
     
@@ -1715,7 +1715,7 @@ and updates it when the <code>onChange</code> event raises.</p>
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/sixach/wp-react-hooks/blob/cf4ff9016a9e31c0967e79b54959f38c9a944d37/src/useNormalizeJsonify/index.js#L21-L25'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/sixach/wp-react-hooks/blob/3720025802d2ac2b2fdf7137586de9493fdd673c/src/useNormalizeJsonify/index.js#L21-L25'>
       <span>src/useNormalizeJsonify/index.js</span>
       </a>
     
@@ -1800,7 +1800,7 @@ and updates it when the <code>onChange</code> event raises.</p>
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/sixach/wp-react-hooks/blob/cf4ff9016a9e31c0967e79b54959f38c9a944d37/src/usePostTypeNameRestBase/index.js#L41-L44'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/sixach/wp-react-hooks/blob/3720025802d2ac2b2fdf7137586de9493fdd673c/src/usePostTypeNameRestBase/index.js#L41-L44'>
       <span>src/usePostTypeNameRestBase/index.js</span>
       </a>
     
@@ -1883,7 +1883,7 @@ REST-API base key extraction from the given string value.</p>
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/sixach/wp-react-hooks/blob/cf4ff9016a9e31c0967e79b54959f38c9a944d37/src/usePreparePosts/index.js#L37-L48'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/sixach/wp-react-hooks/blob/3720025802d2ac2b2fdf7137586de9493fdd673c/src/usePreparePosts/index.js#L39-L50'>
       <span>src/usePreparePosts/index.js</span>
       </a>
     
@@ -1986,7 +1986,7 @@ and slices the query according to the maximum limit determined.</p>
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/sixach/wp-react-hooks/blob/cf4ff9016a9e31c0967e79b54959f38c9a944d37/src/useTimeout/index.js#L23-L56'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/sixach/wp-react-hooks/blob/3720025802d2ac2b2fdf7137586de9493fdd673c/src/useTimeout/index.js#L23-L56'>
       <span>src/useTimeout/index.js</span>
       </a>
     
@@ -2080,7 +2080,7 @@ start();</pre>
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/sixach/wp-react-hooks/blob/cf4ff9016a9e31c0967e79b54959f38c9a944d37/src/useUpdatePostMeta/index.js#L39-L51'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/sixach/wp-react-hooks/blob/3720025802d2ac2b2fdf7137586de9493fdd673c/src/useUpdatePostMeta/index.js#L39-L51'>
       <span>src/useUpdatePostMeta/index.js</span>
       </a>
     
@@ -2190,7 +2190,7 @@ start();</pre>
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/sixach/wp-react-hooks/blob/cf4ff9016a9e31c0967e79b54959f38c9a944d37/src/useVisibilityClassNames/index.js#L49-L57'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/sixach/wp-react-hooks/blob/3720025802d2ac2b2fdf7137586de9493fdd673c/src/useVisibilityClassNames/index.js#L49-L57'>
       <span>src/useVisibilityClassNames/index.js</span>
       </a>
     

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "@sixa/wp-react-hooks",
-	"version": "1.9.0",
+	"version": "1.9.1",
 	"lockfileVersion": 2,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "@sixa/wp-react-hooks",
-			"version": "1.9.0",
+			"version": "1.9.1",
 			"license": "GPL-3.0-or-later",
 			"dependencies": {
 				"@sixa/wp-block-utils": "1.1.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
 			"version": "1.9.1",
 			"license": "GPL-3.0-or-later",
 			"dependencies": {
-				"@sixa/wp-block-utils": "1.1.0",
+				"@sixa/wp-block-utils": "1.2.0",
 				"@wordpress/api-fetch": "5.2.6",
 				"@wordpress/data": "6.1.5",
 				"@wordpress/element": "4.0.4",
@@ -2813,9 +2813,9 @@
 			}
 		},
 		"node_modules/@sixa/wp-block-utils": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/@sixa/wp-block-utils/-/wp-block-utils-1.1.0.tgz",
-			"integrity": "sha512-gTfB2sg2Cp1BFq6hGNLV/FSrNkZwwH9aon7MOs/jmlnDM6L0v9nXFVixue1n91PrAMSKG1DqIomB09z/oZAuXw==",
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/@sixa/wp-block-utils/-/wp-block-utils-1.2.0.tgz",
+			"integrity": "sha512-ebfnB/4iek5n1vEUSVn4Ewavo34rI04BvFvtZp8OuGlIc13dqTISPFEN6MsMIkhbuNbzrksCoykNiESuUc7yjA==",
 			"dependencies": {
 				"@wordpress/api-fetch": "5.2.6",
 				"@wordpress/html-entities": "3.2.3",
@@ -2824,7 +2824,7 @@
 				"classnames": "2.3.1",
 				"lodash": "4.17.21",
 				"rename-keys": "2.0.1",
-				"slugify": "1.6.3",
+				"slugify": "1.6.5",
 				"striptags": "3.2.0"
 			}
 		},
@@ -21134,9 +21134,9 @@
 			}
 		},
 		"node_modules/slugify": {
-			"version": "1.6.3",
-			"resolved": "https://registry.npmjs.org/slugify/-/slugify-1.6.3.tgz",
-			"integrity": "sha512-1MPyqnIhgiq+/0iDJyqSJHENdnH5MMIlgJIBxmkRMzTNKlS/QsN5dXsB+MdDq4E6w0g9jFA4XOTRkVDjDae/2w==",
+			"version": "1.6.5",
+			"resolved": "https://registry.npmjs.org/slugify/-/slugify-1.6.5.tgz",
+			"integrity": "sha512-8mo9bslnBO3tr5PEVFzMPIWwWnipGS0xVbYf65zxDqfNwmzYn1LpiKNrR6DlClusuvo+hDHd1zKpmfAe83NQSQ==",
 			"engines": {
 				"node": ">=8.0.0"
 			}
@@ -27220,9 +27220,9 @@
 			}
 		},
 		"@sixa/wp-block-utils": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/@sixa/wp-block-utils/-/wp-block-utils-1.1.0.tgz",
-			"integrity": "sha512-gTfB2sg2Cp1BFq6hGNLV/FSrNkZwwH9aon7MOs/jmlnDM6L0v9nXFVixue1n91PrAMSKG1DqIomB09z/oZAuXw==",
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/@sixa/wp-block-utils/-/wp-block-utils-1.2.0.tgz",
+			"integrity": "sha512-ebfnB/4iek5n1vEUSVn4Ewavo34rI04BvFvtZp8OuGlIc13dqTISPFEN6MsMIkhbuNbzrksCoykNiESuUc7yjA==",
 			"requires": {
 				"@wordpress/api-fetch": "5.2.6",
 				"@wordpress/html-entities": "3.2.3",
@@ -27231,7 +27231,7 @@
 				"classnames": "2.3.1",
 				"lodash": "4.17.21",
 				"rename-keys": "2.0.1",
-				"slugify": "1.6.3",
+				"slugify": "1.6.5",
 				"striptags": "3.2.0"
 			}
 		},
@@ -41164,9 +41164,9 @@
 			}
 		},
 		"slugify": {
-			"version": "1.6.3",
-			"resolved": "https://registry.npmjs.org/slugify/-/slugify-1.6.3.tgz",
-			"integrity": "sha512-1MPyqnIhgiq+/0iDJyqSJHENdnH5MMIlgJIBxmkRMzTNKlS/QsN5dXsB+MdDq4E6w0g9jFA4XOTRkVDjDae/2w=="
+			"version": "1.6.5",
+			"resolved": "https://registry.npmjs.org/slugify/-/slugify-1.6.5.tgz",
+			"integrity": "sha512-8mo9bslnBO3tr5PEVFzMPIWwWnipGS0xVbYf65zxDqfNwmzYn1LpiKNrR6DlClusuvo+hDHd1zKpmfAe83NQSQ=="
 		},
 		"snapdragon": {
 			"version": "0.8.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@sixa/wp-react-hooks",
-	"version": "1.9.0",
+	"version": "1.9.1",
 	"description": "A collection of most used React hooks crafted for the sixa projects.",
 	"keywords": [
 		"sixa",

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
 		]
 	},
 	"dependencies": {
-		"@sixa/wp-block-utils": "1.1.0",
+		"@sixa/wp-block-utils": "1.2.0",
 		"@wordpress/api-fetch": "5.2.6",
 		"@wordpress/data": "6.1.5",
 		"@wordpress/element": "4.0.4",

--- a/src/usePreparePosts/index.js
+++ b/src/usePreparePosts/index.js
@@ -3,7 +3,7 @@
  *
  * @ignore
  */
-import { find, map, slice } from 'lodash';
+import {filter, includes, slice} from 'lodash';
 
 /**
  * Utility helper methods specific for Sixa projects.
@@ -39,7 +39,7 @@ function usePreparePosts( ids = [], limit = 3, query ) {
 		() => ( {
 			havePosts: isNonEmptyArray( query ),
 			maxLimit: query?.length,
-			slicedQuery: isNonEmptyArray( ids ) ? map( ids, ( id ) => find( query, [ 'id', id ] ) ) : slice( query, 0, limit ),
+			slicedQuery: isNonEmptyArray( ids ) && isNonEmptyArray( query )? filter( query, ( { id } ) => includes( ids, id ) ) : slice( query, 0, limit ),
 		} ),
 		[ ids, limit, query ]
 	);

--- a/src/usePreparePosts/index.js
+++ b/src/usePreparePosts/index.js
@@ -3,7 +3,7 @@
  *
  * @ignore
  */
-import { slice } from 'lodash';
+import slice from 'lodash/slice';
 
 /**
  * Utility helper methods specific for Sixa projects.
@@ -25,6 +25,8 @@ import { useMemo } from '@wordpress/element';
  * and slices the query according to the maximum limit determined.
  *
  * @function
+ * @since       1.9.1
+ * 				Avoid returning undefined in case no match was found in the query filtering.
  * @since       1.2.0
  * @param       {Array}     ids      Handpicked post ids.
  * @param       {number}    limit    Maximum number of posts to show.

--- a/src/usePreparePosts/index.js
+++ b/src/usePreparePosts/index.js
@@ -3,7 +3,7 @@
  *
  * @ignore
  */
-import { filter, includes, slice } from 'lodash';
+import { slice, forEach, find } from 'lodash';
 
 /**
  * Utility helper methods specific for Sixa projects.
@@ -35,11 +35,21 @@ import { useMemo } from '@wordpress/element';
  * const { havePosts, maxLimit, slicedQuery } = usePreparePosts( [2], 3, [ { id: 1, title: 'Post A' }, { id: 2, title: 'Post B' } ] );
  */
 function usePreparePosts( ids = [], limit = 3, query ) {
+	const filterExisting = ( values, collection ) => {
+		const existing = [];
+		forEach( values, ( value ) => {
+			const match = find( collection, [ 'id', value ] );
+			if ( Boolean( match ) ) {
+				existing.push( match );
+			}
+		} );
+		return existing;
+	};
 	const { havePosts, maxLimit, slicedQuery } = useMemo(
 		() => ( {
 			havePosts: isNonEmptyArray( query ),
 			maxLimit: query?.length,
-			slicedQuery: isNonEmptyArray( ids ) && isNonEmptyArray( query ) ? filter( query, ( { id } ) => includes( ids, id ) ) : slice( query, 0, limit ),
+			slicedQuery: isNonEmptyArray( ids ) && isNonEmptyArray( query ) ? filterExisting( ids, query ) : slice( query, 0, limit ),
 		} ),
 		[ ids, limit, query ]
 	);

--- a/src/usePreparePosts/index.js
+++ b/src/usePreparePosts/index.js
@@ -3,7 +3,7 @@
  *
  * @ignore
  */
-import {filter, includes, slice} from 'lodash';
+import { filter, includes, slice } from 'lodash';
 
 /**
  * Utility helper methods specific for Sixa projects.
@@ -39,7 +39,7 @@ function usePreparePosts( ids = [], limit = 3, query ) {
 		() => ( {
 			havePosts: isNonEmptyArray( query ),
 			maxLimit: query?.length,
-			slicedQuery: isNonEmptyArray( ids ) && isNonEmptyArray( query )? filter( query, ( { id } ) => includes( ids, id ) ) : slice( query, 0, limit ),
+			slicedQuery: isNonEmptyArray( ids ) && isNonEmptyArray( query ) ? filter( query, ( { id } ) => includes( ids, id ) ) : slice( query, 0, limit ),
 		} ),
 		[ ids, limit, query ]
 	);

--- a/src/usePreparePosts/index.js
+++ b/src/usePreparePosts/index.js
@@ -3,14 +3,14 @@
  *
  * @ignore
  */
-import { slice, forEach, find } from 'lodash';
+import { slice } from 'lodash';
 
 /**
  * Utility helper methods specific for Sixa projects.
  *
  * @ignore
  */
-import { isNonEmptyArray } from '@sixa/wp-block-utils';
+import { isNonEmptyArray, filterCollectionByValues } from '@sixa/wp-block-utils';
 
 /**
  * WordPress specific abstraction layer atop React.
@@ -35,21 +35,11 @@ import { useMemo } from '@wordpress/element';
  * const { havePosts, maxLimit, slicedQuery } = usePreparePosts( [2], 3, [ { id: 1, title: 'Post A' }, { id: 2, title: 'Post B' } ] );
  */
 function usePreparePosts( ids = [], limit = 3, query ) {
-	const filterExisting = ( values, collection ) => {
-		const existing = [];
-		forEach( values, ( value ) => {
-			const match = find( collection, [ 'id', value ] );
-			if ( Boolean( match ) ) {
-				existing.push( match );
-			}
-		} );
-		return existing;
-	};
 	const { havePosts, maxLimit, slicedQuery } = useMemo(
 		() => ( {
 			havePosts: isNonEmptyArray( query ),
 			maxLimit: query?.length,
-			slicedQuery: isNonEmptyArray( ids ) && isNonEmptyArray( query ) ? filterExisting( ids, query ) : slice( query, 0, limit ),
+			slicedQuery: isNonEmptyArray( ids ) && isNonEmptyArray( query ) ? filterCollectionByValues( ids, query ) : slice( query, 0, limit ),
 		} ),
 		[ ids, limit, query ]
 	);


### PR DESCRIPTION
It appears that it's possible that by the time `usePreparePosts` is called, `query` may not have fully loaded such that `''` is passed rather than a valid array of post objects. In these instances, `find` returns `undefined` for every `id` it checks. This is because `find` returns `undefined` in case no match was found. Note that the same would happen if `id` contained an invalid or a stale reference (for instance the ID of a post that was deleted).

For simplicity and to speed things up for the first load, I have added the `isNonEmptyArray` condition for `query` as well. Speaking of this variable, would we be able to update the [default value of `query`](https://github.com/sixach/wp-react-hooks/blob/main/src/useGetPosts/index.js#L69) from an empty string to an empty array? Personally I would feel more comfortable knowing default values share the type of the intended values. Additionally, this would lift the requirements on `query` and the `isNonEmptyArray` condition could be removed. 

My proposal for `useGetPosts` is shown in #55.

This PR fixes the issue on my local in [Responsive slide (item) widths #39](https://github.com/sixach/wp-block-slider/pull/39)