### PR TITLE
useGetPosts simplification

### DIFF
--- a/src/useGetPosts/index.js
+++ b/src/useGetPosts/index.js
@@ -67,23 +67,21 @@ import { apiClient } from '../utils';
 function useGetPosts( args = {}, clientId, postType ) {
 	const [ options, setOptions ] = useState( [] );
 	const [ query, setQuery ] = useState( '' );
-	const [ loading, setLoading ] = useToggle();
+	const [ loading, setLoading ] = useToggle( true );
 	const toast = useToast();
 
 	useDeepCompareEffect( () => {
-		setLoading();
 		apiClient
 			.get( `/wp/v2/${ postType }`, { per_page: -1, post_status: 'publish', ...args } )
 			.then( ( data ) => {
 				setOptions( selectOptions( data, { id: 'value', 'title.rendered': 'label' }, [] ) );
 				setQuery( data );
-				setLoading();
 			} )
 			.catch( () => {
 				setQuery( [] );
-				setLoading();
 				toast( __( 'Error: Couldn’t retrieve posts via API.', 'sixa' ), 'error' );
-			} );
+			} )
+			.finally( setLoading );
 	}, [ args, clientId, postType ] );
 
 	return { isLoading: loading, postsOptions: options, postsQuery: query };

--- a/src/useGetPosts/index.js
+++ b/src/useGetPosts/index.js
@@ -59,7 +59,7 @@ import { apiClient } from '../utils';
  */
 function useGetPosts( args = {}, clientId, postType ) {
 	const [ options, setOptions ] = useState( [] );
-	const [ query, setQuery ] = useState( [] );
+	const [ query, setQuery ] = useState( '' );
 	const [ loading, setLoading ] = useState( true );
 	const toast = useToast();
 

--- a/src/useGetPosts/index.js
+++ b/src/useGetPosts/index.js
@@ -37,13 +37,6 @@ import useDeepCompareEffect from 'use-deep-compare-effect';
 import useToast from '../useToast';
 
 /**
- * Toggling the value of the state.
- *
- * @ignore
- */
-import useToggle from '../useToggle';
-
-/**
  * API connection interface for setting and receiveing API key.
  *
  * @ignore
@@ -67,10 +60,11 @@ import { apiClient } from '../utils';
 function useGetPosts( args = {}, clientId, postType ) {
 	const [ options, setOptions ] = useState( [] );
 	const [ query, setQuery ] = useState( [] );
-	const [ loading, setLoading ] = useToggle( true );
+	const [ loading, setLoading ] = useState( true );
 	const toast = useToast();
 
 	useDeepCompareEffect( () => {
+		setLoading( true );
 		apiClient
 			.get( `/wp/v2/${ postType }`, { per_page: -1, post_status: 'publish', ...args } )
 			.then( ( data ) => {
@@ -81,7 +75,9 @@ function useGetPosts( args = {}, clientId, postType ) {
 				setQuery( [] );
 				toast( __( 'Error: Couldn’t retrieve posts via API.', 'sixa' ), 'error' );
 			} )
-			.finally( setLoading );
+			.then( () => {
+				setLoading( false );
+			} );
 	}, [ args, clientId, postType ] );
 
 	return { isLoading: loading, postsOptions: options, postsQuery: query };

--- a/src/useGetPosts/index.js
+++ b/src/useGetPosts/index.js
@@ -66,7 +66,7 @@ import { apiClient } from '../utils';
  */
 function useGetPosts( args = {}, clientId, postType ) {
 	const [ options, setOptions ] = useState( [] );
-	const [ query, setQuery ] = useState( '' );
+	const [ query, setQuery ] = useState( [] );
 	const [ loading, setLoading ] = useToggle( true );
 	const toast = useToast();
 


### PR DESCRIPTION
This PR proposes a few minor changes in `useGetPosts` to simplify the function and to make it more robust:

**1. Use `true` default value for `loading`**
Currently, the initial value of `loading` is `false`. As a consequence, the hook is re-executed almost immediately after it is being called for the first time. Similarly, the parent component using the hook is re-rendered almost immediately after it's initial render.
This also allows us to simplify the subsequent function calls a little with a new `finally` block.

**2. Use `[]` default value for `query`**:
This is mostly a proposal to guarantee that `query` is always an array.
