### PR TITLE
Updated .npmignore

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -63,6 +63,7 @@ docs/
 # .ignore files and development configs
 .editorconfig
 .eslintignore
+.eslintrc.js
 .gitattributes
 .prettierignore
 .prettierrc.js
@@ -72,3 +73,6 @@ package-lock.json
 
 # Source files
 src/
+
+# GitHub configuration
+.github


### PR DESCRIPTION
This PR just adds a few more files to `.npmignore` that should not be included in the NPM package.