### PR TITLE
useGetCurrentPost 🪝

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -2,7 +2,7 @@
 <html lang="en">
 <head>
   <meta charset='utf-8'>
-  <title>@sixa/wp-react-hooks 1.11.0 | Documentation</title>
+  <title>@sixa/wp-react-hooks 1.12.0 | Documentation</title>
   <meta name='description' content='A collection of most used React hooks crafted for the sixa projects.'>
   <meta name='viewport' content='width=device-width,initial-scale=1'>
   <link href='assets/bass.css' rel='stylesheet'>
@@ -15,7 +15,7 @@
       <div id='split-left' class='overflow-auto fs0 height-viewport-100'>
         <div class='py1 px2'>
           <h3 class='mb0 no-anchor'>@sixa/wp-react-hooks</h3>
-          <div class='mb1'><code>1.11.0</code></div>
+          <div class='mb1'><code>1.12.0</code></div>
           <input
             placeholder='Filter'
             id='filter-input'
@@ -99,6 +99,16 @@
               
                 
                 <li><a
+                  href='#usegetcurrentpost'
+                  class="">
+                  useGetCurrentPost
+                  
+                </a>
+                
+                </li>
+              
+                
+                <li><a
                   href='#usegetmediatype'
                   class="">
                   useGetMediaType
@@ -172,6 +182,16 @@
                   href='#usegetproductterms'
                   class="">
                   useGetProductTerms
+                  
+                </a>
+                
+                </li>
+              
+                
+                <li><a
+                  href='#usegetsitedata'
+                  class="">
+                  useGetSiteData
                   
                 </a>
                 
@@ -297,7 +317,7 @@
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/sixach/wp-react-hooks/blob/6522459ef273723ae2ddcaa8ab40437369dfe723/src/useActiveTab/index.js#L28-L31'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/sixach/wp-react-hooks/blob/8a98b802b4d18a5b8ff0b61704b54c31d03db5d3/src/useActiveTab/index.js#L28-L31'>
       <span>src/useActiveTab/index.js</span>
       </a>
     
@@ -388,7 +408,7 @@
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/sixach/wp-react-hooks/blob/6522459ef273723ae2ddcaa8ab40437369dfe723/src/useColumnsProps/index.js#L55-L63'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/sixach/wp-react-hooks/blob/8a98b802b4d18a5b8ff0b61704b54c31d03db5d3/src/useColumnsProps/index.js#L55-L63'>
       <span>src/useColumnsProps/index.js</span>
       </a>
     
@@ -475,7 +495,7 @@ along with inline CSS style for the gap range defined viewport-wide.</p>
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/sixach/wp-react-hooks/blob/6522459ef273723ae2ddcaa8ab40437369dfe723/src/useConditionalRef/index.js#L21-L34'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/sixach/wp-react-hooks/blob/8a98b802b4d18a5b8ff0b61704b54c31d03db5d3/src/useConditionalRef/index.js#L21-L34'>
       <span>src/useConditionalRef/index.js</span>
       </a>
     
@@ -569,7 +589,7 @@ along with inline CSS style for the gap range defined viewport-wide.</p>
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/sixach/wp-react-hooks/blob/6522459ef273723ae2ddcaa8ab40437369dfe723/src/useDidMount/index.js#L29-L35'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/sixach/wp-react-hooks/blob/8a98b802b4d18a5b8ff0b61704b54c31d03db5d3/src/useDidMount/index.js#L29-L35'>
       <span>src/useDidMount/index.js</span>
       </a>
     
@@ -652,7 +672,7 @@ along with inline CSS style for the gap range defined viewport-wide.</p>
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/sixach/wp-react-hooks/blob/6522459ef273723ae2ddcaa8ab40437369dfe723/src/useDidUpdate/index.js#L25-L35'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/sixach/wp-react-hooks/blob/8a98b802b4d18a5b8ff0b61704b54c31d03db5d3/src/useDidUpdate/index.js#L25-L35'>
       <span>src/useDidUpdate/index.js</span>
       </a>
     
@@ -747,7 +767,7 @@ conditions to fire callback when one of the conditions changes.</p>
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/sixach/wp-react-hooks/blob/6522459ef273723ae2ddcaa8ab40437369dfe723/src/useFindPostById/index.js#L29-L37'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/sixach/wp-react-hooks/blob/8a98b802b4d18a5b8ff0b61704b54c31d03db5d3/src/useFindPostById/index.js#L29-L37'>
       <span>src/useFindPostById/index.js</span>
       </a>
     
@@ -839,7 +859,7 @@ and maintains the state of change when it happens.</p>
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/sixach/wp-react-hooks/blob/6522459ef273723ae2ddcaa8ab40437369dfe723/src/useGetBlockLayout/index.js#L30-L33'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/sixach/wp-react-hooks/blob/8a98b802b4d18a5b8ff0b61704b54c31d03db5d3/src/useGetBlockLayout/index.js#L30-L33'>
       <span>src/useGetBlockLayout/index.js</span>
       </a>
     
@@ -918,12 +938,103 @@ and maintains the state of change when it happens.</p>
   
   <div class='clearfix'>
     
+    <h3 class='fl m0' id='usegetcurrentpost'>
+      useGetCurrentPost
+    </h3>
+    
+    
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/sixach/wp-react-hooks/blob/8a98b802b4d18a5b8ff0b61704b54c31d03db5d3/src/useGetCurrentPost/index.js#L22-L35'>
+      <span>src/useGetCurrentPost/index.js</span>
+      </a>
+    
+  </div>
+  
+
+  <p>Retrieves the current post object given the post ID and post-type.</p>
+
+    <div class='pre p1 fill-light mt0'>useGetCurrentPost(postId: <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number">number</a>, postType: <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String">string</a>): <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object">Object</a></div>
+  
+  
+
+  
+  
+  
+  
+  
+  <div>Since: 1.12.0</div>
+
+  
+    <div class='py1 quiet mt1 prose-big'>Parameters</div>
+    <div class='prose'>
+      
+        <div class='space-bottom0'>
+          <div>
+            <span class='code bold'>postId</span> <code class='quiet'>(<a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number">number</a>)</code>
+	    Post ID.
+
+          </div>
+          
+        </div>
+      
+        <div class='space-bottom0'>
+          <div>
+            <span class='code bold'>postType</span> <code class='quiet'>(<a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String">string</a>)</code>
+	    Post-type name (key).
+
+          </div>
+          
+        </div>
+      
+    </div>
+  
+
+  
+
+  
+    
+      <div class='py1 quiet mt1 prose-big'>Returns</div>
+      <code><a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object">Object</a></code>:
+        Returns the post object.
+
+      
+    
+  
+
+  
+
+  
+
+  
+    <div class='py1 quiet mt1 prose-big'>Example</div>
+    
+      
+      <pre class='p1 overflow-auto round fill-light'><span class="hljs-keyword">const</span> currentPost = useGetCurrentPost( <span class="hljs-number">748</span>, <span class="hljs-string">&#x27;page&#x27;</span> );</pre>
+    
+  
+
+  
+
+  
+
+  
+
+  
+</section>
+
+          
+        
+          
+          <section class='p2 mb2 clearfix bg-white minishadow'>
+
+  
+  <div class='clearfix'>
+    
     <h3 class='fl m0' id='usegetmediatype'>
       useGetMediaType
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/sixach/wp-react-hooks/blob/6522459ef273723ae2ddcaa8ab40437369dfe723/src/useGetMediaType/index.js#L44-L81'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/sixach/wp-react-hooks/blob/8a98b802b4d18a5b8ff0b61704b54c31d03db5d3/src/useGetMediaType/index.js#L44-L81'>
       <span>src/useGetMediaType/index.js</span>
       </a>
     
@@ -1005,7 +1116,7 @@ and maintains the state of change when it happens.</p>
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/sixach/wp-react-hooks/blob/6522459ef273723ae2ddcaa8ab40437369dfe723/src/useToast/index.js#L21-L26'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/sixach/wp-react-hooks/blob/8a98b802b4d18a5b8ff0b61704b54c31d03db5d3/src/useToast/index.js#L21-L26'>
       <span>src/useToast/index.js</span>
       </a>
     
@@ -1074,7 +1185,7 @@ toast( <span class="hljs-string">&#x27;Text to display as a toast message!&#x27;
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/sixach/wp-react-hooks/blob/6522459ef273723ae2ddcaa8ab40437369dfe723/src/useGetNodeList/index.js#L51-L68'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/sixach/wp-react-hooks/blob/8a98b802b4d18a5b8ff0b61704b54c31d03db5d3/src/useGetNodeList/index.js#L51-L68'>
       <span>src/useGetNodeList/index.js</span>
       </a>
     
@@ -1166,7 +1277,7 @@ toast( <span class="hljs-string">&#x27;Text to display as a toast message!&#x27;
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/sixach/wp-react-hooks/blob/6522459ef273723ae2ddcaa8ab40437369dfe723/src/useGetPostMeta/index.js#L28-L40'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/sixach/wp-react-hooks/blob/8a98b802b4d18a5b8ff0b61704b54c31d03db5d3/src/useGetPostMeta/index.js#L28-L40'>
       <span>src/useGetPostMeta/index.js</span>
       </a>
     
@@ -1248,7 +1359,7 @@ toast( <span class="hljs-string">&#x27;Text to display as a toast message!&#x27;
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/sixach/wp-react-hooks/blob/6522459ef273723ae2ddcaa8ab40437369dfe723/src/useGetPosts/index.js#L60-L84'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/sixach/wp-react-hooks/blob/8a98b802b4d18a5b8ff0b61704b54c31d03db5d3/src/useGetPosts/index.js#L60-L84'>
       <span>src/useGetPosts/index.js</span>
       </a>
     
@@ -1350,7 +1461,7 @@ this list when any of the direct arguments changed.</p>
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/sixach/wp-react-hooks/blob/6522459ef273723ae2ddcaa8ab40437369dfe723/src/useToggle/index.js#L30-L32'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/sixach/wp-react-hooks/blob/8a98b802b4d18a5b8ff0b61704b54c31d03db5d3/src/useToggle/index.js#L30-L32'>
       <span>src/useToggle/index.js</span>
       </a>
     
@@ -1444,7 +1555,7 @@ this list when any of the direct arguments changed.</p>
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/sixach/wp-react-hooks/blob/6522459ef273723ae2ddcaa8ab40437369dfe723/src/useGetProducts/index.js#L66-L89'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/sixach/wp-react-hooks/blob/8a98b802b4d18a5b8ff0b61704b54c31d03db5d3/src/useGetProducts/index.js#L66-L89'>
       <span>src/useGetProducts/index.js</span>
       </a>
     
@@ -1537,7 +1648,7 @@ this list when any of the direct arguments changed.</p>
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/sixach/wp-react-hooks/blob/6522459ef273723ae2ddcaa8ab40437369dfe723/src/useGetProductTerms/index.js#L66-L89'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/sixach/wp-react-hooks/blob/8a98b802b4d18a5b8ff0b61704b54c31d03db5d3/src/useGetProductTerms/index.js#L66-L89'>
       <span>src/useGetProductTerms/index.js</span>
       </a>
     
@@ -1625,12 +1736,95 @@ this list when any of the direct arguments changed.</p>
   
   <div class='clearfix'>
     
+    <h3 class='fl m0' id='usegetsitedata'>
+      useGetSiteData
+    </h3>
+    
+    
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/sixach/wp-react-hooks/blob/8a98b802b4d18a5b8ff0b61704b54c31d03db5d3/src/useGetSiteData/index.js#L29-L41'>
+      <span>src/useGetSiteData/index.js</span>
+      </a>
+    
+  </div>
+  
+
+  <p>Retrieves the current site data or object.</p>
+
+    <div class='pre p1 fill-light mt0'>useGetSiteData(dependencies: <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array">Array</a>): <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object">Object</a></div>
+  
+  
+
+  
+  
+  
+  
+  
+  <div>Since: 1.12.0</div>
+
+  
+    <div class='py1 quiet mt1 prose-big'>Parameters</div>
+    <div class='prose'>
+      
+        <div class='space-bottom0'>
+          <div>
+            <span class='code bold'>dependencies</span> <code class='quiet'>(<a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array">Array</a>
+            = <code>[]</code>)</code>
+	    An array of optional dependencies to refresh the hook output.
+
+          </div>
+          
+        </div>
+      
+    </div>
+  
+
+  
+
+  
+    
+      <div class='py1 quiet mt1 prose-big'>Returns</div>
+      <code><a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object">Object</a></code>:
+        Returns site data and title within an object.
+
+      
+    
+  
+
+  
+
+  
+
+  
+    <div class='py1 quiet mt1 prose-big'>Example</div>
+    
+      
+      <pre class='p1 overflow-auto round fill-light'><span class="hljs-keyword">const</span> { siteTitle } = useGetSiteData();</pre>
+    
+  
+
+  
+
+  
+
+  
+
+  
+</section>
+
+          
+        
+          
+          <section class='p2 mb2 clearfix bg-white minishadow'>
+
+  
+  <div class='clearfix'>
+    
     <h3 class='fl m0' id='usegetterms'>
       useGetTerms
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/sixach/wp-react-hooks/blob/6522459ef273723ae2ddcaa8ab40437369dfe723/src/useGetTerms/index.js#L66-L89'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/sixach/wp-react-hooks/blob/8a98b802b4d18a5b8ff0b61704b54c31d03db5d3/src/useGetTerms/index.js#L66-L89'>
       <span>src/useGetTerms/index.js</span>
       </a>
     
@@ -1723,7 +1917,7 @@ this list when any of the direct arguments changed.</p>
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/sixach/wp-react-hooks/blob/6522459ef273723ae2ddcaa8ab40437369dfe723/src/useInnerBlocksProps/index.js#L27-L27'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/sixach/wp-react-hooks/blob/8a98b802b4d18a5b8ff0b61704b54c31d03db5d3/src/useInnerBlocksProps/index.js#L27-L27'>
       <span>src/useInnerBlocksProps/index.js</span>
       </a>
     
@@ -1788,7 +1982,7 @@ this list when any of the direct arguments changed.</p>
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/sixach/wp-react-hooks/blob/6522459ef273723ae2ddcaa8ab40437369dfe723/src/useInputValue/index.js#L22-L29'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/sixach/wp-react-hooks/blob/8a98b802b4d18a5b8ff0b61704b54c31d03db5d3/src/useInputValue/index.js#L22-L29'>
       <span>src/useInputValue/index.js</span>
       </a>
     
@@ -1873,7 +2067,7 @@ and updates it when the <code>onChange</code> event raises.</p>
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/sixach/wp-react-hooks/blob/6522459ef273723ae2ddcaa8ab40437369dfe723/src/useLatLngBounds/index.js#L44-L69'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/sixach/wp-react-hooks/blob/8a98b802b4d18a5b8ff0b61704b54c31d03db5d3/src/useLatLngBounds/index.js#L44-L69'>
       <span>src/useLatLngBounds/index.js</span>
       </a>
     
@@ -1976,7 +2170,7 @@ and updates it when the <code>onChange</code> event raises.</p>
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/sixach/wp-react-hooks/blob/6522459ef273723ae2ddcaa8ab40437369dfe723/src/useNormalizeJsonify/index.js#L21-L25'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/sixach/wp-react-hooks/blob/8a98b802b4d18a5b8ff0b61704b54c31d03db5d3/src/useNormalizeJsonify/index.js#L21-L25'>
       <span>src/useNormalizeJsonify/index.js</span>
       </a>
     
@@ -2061,7 +2255,7 @@ and updates it when the <code>onChange</code> event raises.</p>
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/sixach/wp-react-hooks/blob/6522459ef273723ae2ddcaa8ab40437369dfe723/src/usePostTypeNameRestBase/index.js#L41-L44'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/sixach/wp-react-hooks/blob/8a98b802b4d18a5b8ff0b61704b54c31d03db5d3/src/usePostTypeNameRestBase/index.js#L41-L44'>
       <span>src/usePostTypeNameRestBase/index.js</span>
       </a>
     
@@ -2144,7 +2338,7 @@ REST-API base key extraction from the given string value.</p>
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/sixach/wp-react-hooks/blob/6522459ef273723ae2ddcaa8ab40437369dfe723/src/usePreparePosts/index.js#L39-L50'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/sixach/wp-react-hooks/blob/8a98b802b4d18a5b8ff0b61704b54c31d03db5d3/src/usePreparePosts/index.js#L39-L50'>
       <span>src/usePreparePosts/index.js</span>
       </a>
     
@@ -2247,7 +2441,7 @@ and slices the query according to the maximum limit determined.</p>
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/sixach/wp-react-hooks/blob/6522459ef273723ae2ddcaa8ab40437369dfe723/src/useTimeout/index.js#L23-L56'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/sixach/wp-react-hooks/blob/8a98b802b4d18a5b8ff0b61704b54c31d03db5d3/src/useTimeout/index.js#L23-L56'>
       <span>src/useTimeout/index.js</span>
       </a>
     
@@ -2341,7 +2535,7 @@ start();</pre>
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/sixach/wp-react-hooks/blob/6522459ef273723ae2ddcaa8ab40437369dfe723/src/useUpdatePostMeta/index.js#L39-L51'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/sixach/wp-react-hooks/blob/8a98b802b4d18a5b8ff0b61704b54c31d03db5d3/src/useUpdatePostMeta/index.js#L39-L51'>
       <span>src/useUpdatePostMeta/index.js</span>
       </a>
     
@@ -2451,7 +2645,7 @@ start();</pre>
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/sixach/wp-react-hooks/blob/6522459ef273723ae2ddcaa8ab40437369dfe723/src/useVisibilityClassNames/index.js#L49-L57'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/sixach/wp-react-hooks/blob/8a98b802b4d18a5b8ff0b61704b54c31d03db5d3/src/useVisibilityClassNames/index.js#L49-L57'>
       <span>src/useVisibilityClassNames/index.js</span>
       </a>
     

--- a/src/index.js
+++ b/src/index.js
@@ -5,6 +5,7 @@ export { default as useDidMount } from './useDidMount';
 export { default as useDidUpdate } from './useDidUpdate';
 export { default as useFindPostById } from './useFindPostById';
 export { default as useGetBlockLayout } from './useGetBlockLayout';
+export { default as useGetCurrentPost } from './useGetCurrentPost';
 export { default as useGetMediaType } from './useGetMediaType';
 export { default as useGetNodeList } from './useGetNodeList';
 export { default as useGetPostMeta } from './useGetPostMeta';

--- a/src/useGetCurrentPost/index.js
+++ b/src/useGetCurrentPost/index.js
@@ -23,9 +23,10 @@ function useGetCurrentPost( postId, postType ) {
 	const { currentPost } = useSelect(
 		( select ) => {
 			const { getEditedEntityRecord } = select( 'core' );
+			const _currentPost = getEditedEntityRecord( 'postType', postType, postId );
 
 			return {
-				currentPost: getEditedEntityRecord( 'postType', postType, postId ),
+				currentPost: _currentPost,
 			};
 		},
 		[ postId, postType ]

--- a/src/useGetCurrentPost/index.js
+++ b/src/useGetCurrentPost/index.js
@@ -1,0 +1,37 @@
+/**
+ * Data module to manage application state for both plugins and WordPress itself.
+ * The data module is built upon and shares many of the same core principles of Redux.
+ *
+ * @see    https://developer.wordpress.org/block-editor/reference-guides/packages/packages-data/
+ * @ignore
+ */
+import { useSelect } from '@wordpress/data';
+
+/**
+ * Retrieves the current post object given the post ID and post-type.
+ *
+ * @function
+ * @since      1.12.0
+ * @param      {number}     postId      Post ID.
+ * @param      {string}     postType    Post-type name (key).
+ * @return     {Object}				    Returns the post object.
+ * @example
+ *
+ * const currentPost = useGetCurrentPost( 748, 'page' );
+ */
+function useGetCurrentPost( postId, postType ) {
+	const { currentPost } = useSelect(
+		( select ) => {
+			const { getEditedEntityRecord } = select( 'core' );
+
+			return {
+				currentPost: getEditedEntityRecord( 'postType', postType, postId ),
+			};
+		},
+		[ postId, postType ]
+	);
+
+	return currentPost;
+}
+
+export default useGetCurrentPost;


### PR DESCRIPTION
This PR introduces a new hook allowing to retrieve the current post object given a post ID and post-type name (key).